### PR TITLE
Few items to save spiralling gas costs and allow poster optimization

### DIFF
--- a/contracts/DelFiPrice.sol
+++ b/contracts/DelFiPrice.sol
@@ -12,7 +12,7 @@ contract DelFiPrice is OpenOracleView {
     /**
      * @notice The mapping of medianized prices per symbol
      */
-    mapping(string => uint) public prices;
+    mapping(string => uint64) public prices;
 
     constructor(OpenOraclePriceData data_, address[] memory sources_) public OpenOracleView(data_, sources_) {}
 
@@ -22,33 +22,16 @@ contract DelFiPrice is OpenOracleView {
      * @param messages The messages to post to the oracle
      * @param signatures The signatures for the corresponding messages
      */
-    function postPrices(bytes[] calldata messages, bytes[] calldata signatures) external {
+    function postPrices(bytes[] calldata messages, bytes[] calldata signatures, string[] calldata symbols) external {
         require(messages.length == signatures.length, "messages and signatures must be 1:1");
-
-        // Initialize the list of unique symbols
-        string[] memory symbols = new string[](messages.length);
-        uint numSymbols = 0;
 
         // Post the messages, whatever they are
         for (uint i = 0; i < messages.length; i++) {
-            string memory symbol = OpenOraclePriceData(address(data)).put(messages[i], signatures[i]);
-
-            // Possibly add to the unique symbol set
-            bool found = false;
-            for (uint j = 0; j < symbols.length; j++) {
-                if (keccak256(abi.encodePacked(symbol)) == keccak256(abi.encodePacked(symbols[j]))) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                symbols[i] = symbol;
-                numSymbols += 1;
-            }
+            OpenOraclePriceData(address(data)).put(messages[i], signatures[i]);
         }
 
-        // Recalculate the asset prices
-        for (uint i = 0; i < numSymbols; i++) {
+        // Recalculate the asset prices for the symbols to update
+        for (uint i = 0; i < symbols.length; i++) {
             string memory symbol = symbols[i];
 
             // Calculate the median price and write to storage
@@ -62,16 +45,16 @@ contract DelFiPrice is OpenOracleView {
      * @param sources_ The sources to use when calculating the median price
      * @return median The median price over the set of sources
      */
-    function medianPrice(string memory symbol, address[] memory sources_) public view returns (uint median) {
+    function medianPrice(string memory symbol, address[] memory sources_) public view returns (uint64 median) {
         require(sources_.length > 0, "sources list must not be empty");
 
         uint N = sources_.length;
-        uint[] memory postedPrices = new uint[](N);
+        uint64[] memory postedPrices = new uint64[](N);
         for (uint i = 0; i < N; i++) {
-            ( , uint price) = OpenOraclePriceData(address(data)).get(sources_[i], symbol);
-            postedPrices[i] = price;
+            postedPrices[i] = OpenOraclePriceData(address(data)).getPrice(sources_[i], symbol);
         }
-        uint[] memory sortedPrices = sort(postedPrices);
+
+        uint64[] memory sortedPrices = sort(postedPrices);
         return sortedPrices[N / 2];
     }
 
@@ -80,12 +63,12 @@ contract DelFiPrice is OpenOracleView {
      * @param array Array of integers to sort
      * @return The sorted array of integers
      */
-    function sort(uint[] memory array) private pure returns (uint[] memory) {
+    function sort(uint64[] memory array) private pure returns (uint64[] memory) {
         uint N = array.length;
         for (uint i = 0; i < N; i++) {
             for (uint j = i + 1; j < N; j++) {
                 if (array[i] > array[j]) {
-                    uint tmp = array[i];
+                    uint64 tmp = array[i];
                     array[i] = array[j];
                     array[j] = tmp;
                 }

--- a/contracts/DelFiPrice.sol
+++ b/contracts/DelFiPrice.sol
@@ -10,6 +10,11 @@ import "./OpenOracleView.sol";
  */
 contract DelFiPrice is OpenOracleView {
     /**
+     * @notice The event emitted when a price is written to storage
+     */
+    event Price(string symbol, uint64 price);
+
+    /**
      * @notice The mapping of medianized prices per symbol
      */
     mapping(string => uint64) public prices;
@@ -34,8 +39,10 @@ contract DelFiPrice is OpenOracleView {
         for (uint i = 0; i < symbols.length; i++) {
             string memory symbol = symbols[i];
 
-            // Calculate the median price and write to storage
-            prices[symbol] = medianPrice(symbol, sources);
+            // Calculate the median price, write to storage, and emit an event
+            uint64 price = medianPrice(symbol, sources);
+            prices[symbol] = price;
+            emit Price(symbol, price);
         }
     }
 

--- a/contracts/OpenOracleData.sol
+++ b/contracts/OpenOracleData.sol
@@ -9,7 +9,7 @@ contract OpenOracleData {
     /**
      * @notice The event emitted when a source writes to its storage
      */
-    //event Write(address indexed source, <Key> indexed key, string kind, uint timestamp, <Value> value);
+    //event Write(address indexed source, <Key> indexed key, string kind, uint64 timestamp, <Value> value);
 
     /**
      * @notice Write a bunch of signed datum to the authenticated storage mapping

--- a/contracts/OpenOraclePriceData.sol
+++ b/contracts/OpenOraclePriceData.sol
@@ -5,20 +5,21 @@ import "./OpenOracleData.sol";
 
 /**
  * @title The Open Oracle Price Data Contract
+ * @notice Values stored in this contract should represent a USD price with 6 decimals precision
  * @author Compound Labs, Inc.
  */
 contract OpenOraclePriceData is OpenOracleData {
     /**
      * @notice The event emitted when a source writes to its storage
      */
-    event Write(address indexed source, string indexed key, uint timestamp, uint value);
+    event Write(address indexed source, string indexed key, uint64 timestamp, uint64 value);
 
     /**
      * @notice The fundamental unit of storage for a reporter source
      */
     struct Datum {
-        uint timestamp;
-        uint value;
+        uint64 timestamp;
+        uint64 value;
     }
 
     /**
@@ -38,7 +39,7 @@ contract OpenOraclePriceData is OpenOracleData {
         address source = source(message, signature);
 
         // Decode the message and check the kind
-        (string memory kind, uint timestamp, string memory key, uint value) = abi.decode(message, (string, uint, string, uint));
+        (string memory kind, uint64 timestamp, string memory key, uint64 value) = abi.decode(message, (string, uint64, string, uint64));
         require(keccak256(abi.encodePacked(kind)) == keccak256(abi.encodePacked("prices")), "Kind of data must be 'prices'");
 
         // Only update if newer than stored, according to source
@@ -55,10 +56,20 @@ contract OpenOraclePriceData is OpenOracleData {
      * @notice Read a single key from an authenticated source
      * @param source The verifiable author of the data
      * @param key The selector for the value to return
-     * @return The claimed Unix timestamp for the data and the encoded value (defaults to (0, 0))
+     * @return The claimed Unix timestamp for the data and the price value (defaults to (0, 0))
      */
-    function get(address source, string calldata key) external view returns (uint, uint) {
+    function get(address source, string calldata key) external view returns (uint64, uint64) {
         Datum storage datum = data[source][key];
         return (datum.timestamp, datum.value);
+    }
+
+    /**
+     * @notice Read only the value for a single key from an authenticated source
+     * @param source The verifiable author of the data
+     * @param key The selector for the value to return
+     * @return The price value (defaults to 0)
+     */
+    function getPrice(address source, string calldata key) external view returns (uint64) {
+        return data[source][key].value;
     }
 }

--- a/contracts/OpenOraclePriceData.sol
+++ b/contracts/OpenOraclePriceData.sol
@@ -12,7 +12,7 @@ contract OpenOraclePriceData is OpenOracleData {
     /**
      * @notice The event emitted when a source writes to its storage
      */
-    event Write(address indexed source, string indexed key, uint64 timestamp, uint64 value);
+    event Write(address indexed source, string key, uint64 timestamp, uint64 value);
 
     /**
      * @notice The fundamental unit of storage for a reporter source

--- a/poster/README.md
+++ b/poster/README.md
@@ -42,7 +42,7 @@ import Web3 from 'web3';
 // let sources = [list of sources];
 // let posterKey = ...a key to a wallet holding eth for gas;
 // let viewAddress = "0xDelfiPriceView";
-// let viewFunction = ...view function signature e.g. 'postPrices(bytes[],bytes[])';
+// let viewFunction = ...view function signature e.g. 'postPrices(bytes[],bytes[],string[])';
 // let web3Provider = new Web3("web3Node.com", undefined, {transactionPollingTimeout: 180});
 await poster.main(sources, posterKey, viewAddress, viewFunction, web3Provider);
 ```

--- a/poster/src/index.ts
+++ b/poster/src/index.ts
@@ -7,7 +7,7 @@ async function run() {
     .option('sources', {alias: 's', description: 'Sources to pull price messages from, a list of https endpoints created by open oracle reporters serving open oracle payloads as json', type: 'string'})
     .option('poster_key', {alias: 'k', description: 'Private key holding enough gas to post (try: `file:<file> or env:<env>)`', type: 'string'})
     .option('view_address', {alias: 'a', description: 'Address of open oracle view to post through', type: 'string'})
-    .option('view_function', {alias: 'f', description: 'Function signature for the view', type: 'string', default: 'postPrices(bytes[],bytes[])'})
+    .option('view_function', {alias: 'f', description: 'Function signature for the view', type: 'string', default: 'postPrices(bytes[],bytes[],string[])'})
     .option('web3_provider', {description: 'Web 3 provider', type: 'string', default: 'http://127.0.0.1:8545'})
     .option('timeout', {alias: 't', description: 'How many seconds to wait before retrying with more gas', type: 'number', default: 180})
     .help()

--- a/poster/src/poster.ts
+++ b/poster/src/poster.ts
@@ -56,12 +56,14 @@ function buildTrxData(payloads : DelFiReporterPayload[], functionSig : string) :
 
   let messages = payloads.reduce((a: string[], x) => a.concat(x.messages), []);
   let signatures = payloads.reduce((a: string[], x) => a.concat(x.signatures), []);
+  let priceKeys = payloads.map(x => Object.keys(x.prices));
+  let symbols = new Set(priceKeys.reduce((acc, val) => acc.concat(val)));
 
   // see https://github.com/ethereum/web3.js/blob/2.x/packages/web3-eth-abi/src/AbiCoder.js#L112
   const coder = new AbiCoder();
   return coder.encodeFunctionSignature(functionSig) +
     coder
-    .encodeParameters(types, [messages, signatures])
+    .encodeParameters(types, [messages, signatures, [...symbols]])
     .replace('0x', '');
 }
 

--- a/poster/tests/poster_test.ts
+++ b/poster/tests/poster_test.ts
@@ -45,7 +45,7 @@ describe('building a function call', () => {
 
     let prices = {"eth": "250", "zrx": "300"};
 
-    let data = buildTrxData([{messages, signatures, prices}], "writePrices(bytes[],bytes[])");
+    let data = buildTrxData([{messages, signatures, prices}], "writePrices(bytes[],bytes[],string[])");
 
     let assumedAbi = {
       "constant": false,
@@ -57,7 +57,11 @@ describe('building a function call', () => {
         {
           "name": "whatever",
           "type": "bytes[]"
-        }
+        },
+        {
+          "name": "whatnot",
+          "type": "string[]"
+        },
       ],
       "name": "writePrices",
       "outputs": [],
@@ -67,7 +71,7 @@ describe('building a function call', () => {
     };
 
     // @ts-ignore-start
-    let officialWeb3Encoding = new AbiCoder().encodeFunctionCall(assumedAbi, [messages, signatures]);
+    let officialWeb3Encoding = new AbiCoder().encodeFunctionCall(assumedAbi, [messages, signatures, ['eth', 'zrx']]);
     // @ts-ignore-end
 
     expect(data).toEqual(officialWeb3Encoding);

--- a/sdk/javascript/src/reporter.ts
+++ b/sdk/javascript/src/reporter.ts
@@ -22,7 +22,7 @@ export function fancyParameterDecoder(paramType: string): [string, (any) => any]
   let actualParamType = paramType, actualParamDec = (x) => x;
 
   if (paramType == 'decimal') {
-    actualParamType = 'uint256';
+    actualParamType = 'uint64';
     actualParamDec = (x) => x / 1e6;
   }
 
@@ -39,7 +39,7 @@ export function decode(kind: string, messages: string[]): [number, any, any][] {
   const [kType, kDec] = fancyParameterDecoder(keyType);
   const [vType, vDec] = fancyParameterDecoder(valueType);
   return messages.map((message): [number, any, any] => {
-    const {0: kind_, 1: timestamp, 2: key, 3: value} = web3.eth.abi.decodeParameters(['string', 'uint256', kType, vType], message);
+    const {0: kind_, 1: timestamp, 2: key, 3: value} = web3.eth.abi.decodeParameters(['string', 'uint64', kType, vType], message);
     if (kind_ != kind)
       throw new Error(`Expected data of kind ${kind}, got ${kind_}`);
     return [timestamp, key, value];
@@ -52,7 +52,7 @@ export function fancyParameterEncoder(paramType: string): [string, (any) => any]
   // We add a decimal type for reporter convenience.
   // Decimals are encoded as uints with 18 decimals of precision on-chain.
   if (paramType === 'decimal') {
-    actualParamType = 'uint256';
+    actualParamType = 'uint64';
     actualParamEnc = (x) => web3.utils.toBN(1e6).muln(x).toString();
   }
 
@@ -70,7 +70,7 @@ export function encode(kind: string, timestamp: number, pairs: [any, any][] | ob
   const [vType, vEnc] = fancyParameterEncoder(valueType);
   const actualPairs = Array.isArray(pairs) ? pairs : Object.entries(pairs);
   return actualPairs.map(([key, value]) => {
-    return web3.eth.abi.encodeParameters(['string', 'uint256', kType, vType], [kind, timestamp, kEnc(key), vEnc(value)]);
+    return web3.eth.abi.encodeParameters(['string', 'uint64', kType, vType], [kind, timestamp, kEnc(key), vEnc(value)]);
   });
 }
 

--- a/tests/DelFiPriceTest.js
+++ b/tests/DelFiPriceTest.js
@@ -74,7 +74,9 @@ describe('DelFiPrice', () => {
     const post1 = await postPrices(now, [
       [['ETH', 257]]
     ], ['ETH']);
-    expect(post1.gasUsed).toBeLessThan(105000);
+    expect(post1.gasUsed).toBeLessThan(106000);
+    expect(post1.events.Price.returnValues.symbol).toBe('ETH');
+    expect(post1.events.Price.returnValues.price).numEquals(0);
     console.log('1', post1.gasUsed);
     expect(await getPrice('ETH')).numEquals(0);
 
@@ -91,7 +93,7 @@ describe('DelFiPrice', () => {
         ['ETH', 255]
       ]
     ], ['BTC', 'ETH']);
-    expect(post2.gasUsed).toBeLessThan(260000);
+    expect(post2.gasUsed).toBeLessThan(265000);
     console.log('2', post2.gasUsed);
     expect(await getPrice('BTC')).numEquals(0); // not added to list of symbols to update
     expect(await getPrice('ETH')).numEquals(0);
@@ -113,7 +115,11 @@ describe('DelFiPrice', () => {
         ['ETH', 255]
       ]
     ], ['BTC', 'ETH']);
-    expect(post3a.gasUsed).toBeLessThan(335000);
+    expect(post3a.gasUsed).toBeLessThan(341000);
+    expect(post3a.events.Price[0].returnValues.symbol).toBe('BTC');
+    expect(post3a.events.Price[0].returnValues.price).numEquals(8000e6);
+    expect(post3a.events.Price[1].returnValues.symbol).toBe('ETH');
+    expect(post3a.events.Price[1].returnValues.price).numEquals(255e6);
     console.log('3a', post3a.gasUsed);
     expect(await getPrice('BTC')).numEquals(8000e6);
     expect(await getPrice('ETH')).numEquals(255e6);
@@ -135,7 +141,7 @@ describe('DelFiPrice', () => {
         ['ETH', 255]
       ]
     ], ['BTC', 'ETH']);
-    expect(post3b.gasUsed).toBeLessThan(275000);
+    expect(post3b.gasUsed).toBeLessThan(281000);
     console.log('3b', post3b.gasUsed);
     expect(await getPrice('BTC')).numEquals(8000e6);
     expect(await getPrice('ETH')).numEquals(255e6);
@@ -302,7 +308,7 @@ describe('DelFiPrice', () => {
     ];
 
     const postA = await postPrices(now, big, big[0].map(([k]) => k));
-    expect(postA.gasUsed).toBeLessThan(5.3e6);
+    expect(postA.gasUsed).toBeLessThan(5.4e6);
 
     const postB = await postPrices(now + 1, big, big[0].map(([k]) => k));
     expect(postB.gasUsed).toBeLessThan(3.7e6);


### PR DESCRIPTION
 - pack uint64 instead of uint256 so we use only a single storage slot
 - add back the symbols param to avoid building the list on-chain
  also gives some flexibility to poster
 - add more extensive gas testing

Re: other optimizations:
 - throttling by poster is best supported by having messages signed
 individually
 - view could receive median as a param and verify instead of
 calculating
  this would save the sort, but the sort is cheap compared to the cost
  of reading all the prices from the data contract