### PR TITLE
Upgrade solidity version to 0.6.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           docker_layer_caching: true
       - run:
         |
-          sudo wget https://github.com/ethereum/solidity/releases/download/v0.5.12/solc-static-linux -O /usr/local/bin/solc
+          sudo wget https://github.com/ethereum/solidity/releases/download/v0.6.6/solc-static-linux -O /usr/local/bin/solc
           sudo chmod +x /usr/local/bin/solc
       - checkout
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:13.6.0-alpine3.10
 WORKDIR /open-oracle
-RUN wget https://github.com/ethereum/solidity/releases/download/v0.5.12/solc-static-linux -O /usr/local/bin/solc && chmod +x /usr/local/bin/solc
+RUN wget https://github.com/ethereum/solidity/releases/download/v0.6.6/solc-static-linux -O /usr/local/bin/solc && chmod +x /usr/local/bin/solc
 RUN apk update && apk add --no-cache --virtual .gyp \
     python \
     make \

--- a/contracts/DelFiPrice.sol
+++ b/contracts/DelFiPrice.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.12;
+pragma solidity ^0.6.6;
 pragma experimental ABIEncoderV2;
 
 import "./OpenOraclePriceData.sol";

--- a/contracts/OpenOracleData.sol
+++ b/contracts/OpenOracleData.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.12;
+pragma solidity ^0.6.6;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/contracts/OpenOraclePriceData.sol
+++ b/contracts/OpenOraclePriceData.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.12;
+pragma solidity ^0.6.6;
 
 import "./OpenOracleData.sol";
 

--- a/contracts/OpenOracleView.sol
+++ b/contracts/OpenOracleView.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.12;
+pragma solidity ^0.6.6;
 
 import "./OpenOracleData.sol";
 

--- a/tests/contracts/Test.sol
+++ b/tests/contracts/Test.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.12;
+pragma solidity ^0.6.6;
 pragma experimental ABIEncoderV2;
 
 contract TestOverflow {


### PR DESCRIPTION
Comparison of gas prices for tests/DelFiPriceTest.js
Solidity 0.5.12 vs 0.6.6

```
 should sort even number of sources correctly
Gas used =  242000 vs Gas used =  239942

should sort even number of sources correctly with two assets
Gas used =  540768 vs Gas used =  536398

posting single source should not record a median
Gas used =  147420 vs Gas used =  145446

posting 0 anchor price should guard price and not revert
Gas used =  224811 vs Gas used =  222627

posting some sources should yield correct median
Gas used =  248853 vs Gas used =  246500
Gas used =  174491 vs Gas used =  172126

should not update median if anchor is much higher
Gas used =  304424 vs Gas used =  301958

should not update median if anchor is much lower
Gas used =  303598 vs Gas used =  301168

posting all sources for two assets should sort correctly and yield correct median
Gas used =  633920 vs Gas used =  628762

view should use most recent post with two sources
Gas used =  633920 vs  Gas used =  628762
Gas used =  424233 vs Gas used =  419063
```