### PR TITLE
Manually Set Saddle Build Dir

### DIFF
--- a/tests/IntegrationTest.js
+++ b/tests/IntegrationTest.js
@@ -54,6 +54,7 @@ describe('Integration', () => {
 
       const web3 = new Web3(new DockerProvider('http://ganache:8545', reporter));
       const accounts = await web3.eth.getAccounts();
+      saddle.network_config.build_dir = '.dockerbuild_cp';
       const delfi = await saddle.getContractAt('DelFiPrice', '0x5b1869D9A4C187F2EAa108f3062412ecf0526b24');
 
       expect(await delfi.methods.prices('BTC').call({from: accounts[0]})).numEquals(0);


### PR DESCRIPTION
Saddle expects to find a `solc` build file after compilation. The way we do things, that ends up being in a different directory so that it can come directly from another container's docker build (usually it's `.build/contract.json`). This patch just sets the network config in Saddle to the correct directory, which should solve the current hurdle.