### PR TITLE
Added @types/zen-observable

### DIFF
--- a/poster/package.json
+++ b/poster/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.14",
+    "@types/zen-observable": "^0.8.0",
     "ganache-core": "^2.8.0",
     "jest": "^24.9.0",
     "jest-junit": "^10.0.0",

--- a/poster/yarn.lock
+++ b/poster/yarn.lock
@@ -411,6 +411,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/zen-observable@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
+  integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
+
 "@web3-js/scrypt-shim@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz#0bf7529ab6788311d3e07586f7d89107c3bea2cc"


### PR DESCRIPTION
Currently running `yarn install` in the `poster` folder throws an error (see below). Adding `@types/zen-observable` fixes that.

```
yarn install v1.22.4
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
$ npx tsc
node_modules/@types/node/globals.d.ts:146:14 - error TS2687: All declarations of 'observable' must have identical modifiers.

146     readonly observable: symbol;
                 ~~~~~~~~~~

../../../node_modules/@types/zen-observable/index.d.ts:8:9 - error TS2687: All declarations of 'observable' must have identical modifiers.

8         observable: symbol;
          ~~~~~~~~~~


Found 2 errors.

error Command failed with exit code 2.
```