### PR TITLE
 Cob/deadman cut anchor

### DIFF
--- a/contracts/AnchoredView/AnchoredView.sol
+++ b/contracts/AnchoredView/AnchoredView.sol
@@ -4,99 +4,93 @@ pragma experimental ABIEncoderV2;
 import "./SymbolConfiguration.sol";
 import "../OpenOraclePriceData.sol";
 
-interface CErc20 {
-    function underlying() external view returns (address);
-}
-
 interface AnchorOracle {
     function numBlocksPerPeriod() external view returns (uint); // approximately 1 hour: 60 seconds/minute * 60 minutes/hour * 1 block/15 seconds
 
     function assetPrices(address asset) external view returns (uint);
 
+    struct Anchor {
+        // floor(block.number / numBlocksPerPeriod) + 1
+        uint period;
 
-    /* struct Anchor { */
-    /*     // floor(block.number / numBlocksPerPeriod) + 1 */
-    /*     uint period; */
-
-    /*     // Price in ETH, scaled by 10**18 */
-    /*     uint priceMantissa; */
-    /* } */
-    function anchors(address asset) external view returns (uint, uint);
+        // Price in ETH, scaled by 10**18
+        uint priceMantissa;
+    }
+    function anchors(address asset) external view returns (Anchor memory);
 }
 
 
 /**
  * @notice Price feed conforming to Price Oracle Proxy interface.
  * @dev Use a single open oracle reporter and anchored to and falling back to the Compound v2 oracle system.
+ * @dev The reporter must report at a minimum the USD/ETH price, so that anchor ETH/TOKEN prices can be converted to USD/TOKEN
  * @author Compound Labs, Inc.
  */
 contract AnchoredView is SymbolConfiguration {
-    /// @notice The mapping of posted by source prices per symbol
-    mapping(string => uint256) public _prices;
+    /// @notice The mapping of anchored reporter prices by symbol
+    mapping(string => uint) public _prices;
 
-    /// @notice circuit breaker for using anchor price oracle directly
-    bool public breaker;
+    /// @notice Circuit breaker for using anchor price oracle directly, ignoring reporter
+    bool public reporterBreaker;
 
-    /// @notice circuit breaker for using source price without anchor
-    bool public anchored = true;
+    /// @notice Circuit breaker for using reporter price without anchor
+    bool public anchorBreaker;
 
-    /// @notice the Open Oracle Reporter price source
-    address public immutable source;
+    /// @notice the Open Oracle Reporter price reporter
+    address public immutable reporter;
 
-    /// @notice the anchor oracle ( Compouni Oracle V1 )
+    /// @notice The anchor oracle ( Compound Oracle V1 )
     AnchorOracle public immutable anchor;
 
-    /// @notice the Open Oracle Price Data contract
+    /// @notice The Open Oracle Price Data contract
     OpenOraclePriceData public immutable priceData;
 
     /// @notice The highest ratio of the new median price to the anchor price that will still trigger the median price to be updated
-    uint256 immutable upperBoundAnchorRatio;
+    uint immutable upperBoundAnchorRatio;
 
     /// @notice The lowest ratio of the new median price to the anchor price that will still trigger the median price to be updated
-    uint256 immutable lowerBoundAnchorRatio;
+    uint immutable lowerBoundAnchorRatio;
 
-    /// @notice standard amount for the Dollar
-    uint256 constant oneDollar = 1e6;
+    /// @notice Average blocks per day, for checking anchor staleness
+    /// @dev 1 day / 15
+    uint constant blocksInADay = 5760;
 
     /// @notice The event emitted when the median price is updated
-    event PriceUpdated(string symbol, uint256 price);
+    event PriceUpdated(string symbol, uint price);
 
     /// @notice The event emitted when new prices are posted but the stored price is not updated due to the anchor
-    event PriceGuarded(string symbol, uint256 source, uint256 anchor);
+    event PriceGuarded(string symbol, uint reporter, uint anchor);
 
-    /// @notice The event emitted when source invalidates itself
-    event SourceInvalidated(address source);
+    /// @notice The event emitted when reporter invalidates itself
+    event ReporterInvalidated(address reporter);
 
     /// @notice The event emitted when the anchor is cut for staleness
     event AnchorCut(address anchor);
 
     /**
      * @param data_ Address of the Oracle Data contract
-     * @param source_ The reporter address whose price will be used if it matches the anchor
-     * @param anchor_ The PriceOracleProxy that will be used to verify source price, or serve prices not given by the source
+     * @param reporter_ The reporter address whose price will be used if it matches the anchor
+     * @param anchor_ The PriceOracleProxy that will be used to verify reporter price, or serve prices not given by the reporter
      * @param anchorToleranceMantissa_ The tolerance allowed between the anchor and median. A tolerance of 10e16 means a new median that is 10% off from the anchor will still be saved
      * @param tokens_ The CTokens struct that contains addresses for CToken contracts
      */
     constructor(OpenOraclePriceData data_,
-                address source_,
+                address reporter_,
                 AnchorOracle anchor_,
                 uint anchorToleranceMantissa_,
                 CTokens memory tokens_) SymbolConfiguration(tokens_) public {
-        source = source_;
+        reporter = reporter_;
         anchor = anchor_;
         priceData = data_;
 
         require(anchorToleranceMantissa_ < 100e16, "Anchor Tolerance is too high");
         upperBoundAnchorRatio = 100e16 + anchorToleranceMantissa_;
         lowerBoundAnchorRatio = 100e16 - anchorToleranceMantissa_;
-
-        _prices["USDC"] = oneDollar;
-        _prices["USDT"] = oneDollar;
     }
 
     /**
-     * @notice Post open oracle source prices, and recalculate stored price by comparing to anchor
-     * @dev We let anyone pay to post anything, but only prices from configured source will be stored in the view
+     * @notice Post open oracle reporter prices, and recalculate stored price by comparing to anchor
+     * @dev We let anyone pay to post anything, but only prices from configured reporter will be stored in the view
      * @param messages The messages to post to the oracle
      * @param signatures The signatures for the corresponding messages
      * @param symbols The symbols to compare to anchor for authoritative reading
@@ -110,78 +104,66 @@ contract AnchoredView is SymbolConfiguration {
         }
 
         // load usdc for using in loop to convert anchor prices to dollars
-        uint256 usdcPrice = readAnchor(cUsdcAddress);
+        uint usdcPrice = readAnchor(cUsdcAddress);
 
         // Try to update the view storage
         for (uint i = 0; i < symbols.length; i++) {
-            string memory symbol = symbols[i];
-            address tokenAddress = getCTokenAddress(symbol);
-            uint256 sourcePrice = priceData.getPrice(source, symbol);
-            uint256 anchorPrice = getAnchorInUsd(tokenAddress, usdcPrice);
+            CTokenMetadata memory tokenConfig = getCTokenConfig(symbols[i]);
+            // symbol is not supported in the view, but allow writing to data
+            if (tokenConfig.cTokenAddress == address(0)) continue;
 
-            if (anchorPrice == 0 || tokenAddress == cUsdcAddress || tokenAddress == cUsdtAddress) {
-                emit PriceGuarded(symbol, sourcePrice, anchorPrice);
-            } else {
-                uint256 anchorRatioMantissa = mul(sourcePrice, 100e16) / anchorPrice;
-                // Only update the view's price if the source price is within a bound
-                if (anchorRatioMantissa <= upperBoundAnchorRatio && anchorRatioMantissa >= lowerBoundAnchorRatio) {
-                    // only update and emit event if value changes
-                    if (_prices[symbol] != sourcePrice) {
-                        _prices[symbol] = sourcePrice;
-                        emit PriceUpdated(symbol, sourcePrice);
-                    }
-                } else if (!anchored) {
-                    _prices[symbol] = sourcePrice;
-                    emit PriceUpdated(symbol, sourcePrice);
-                } else {
-                    emit PriceGuarded(symbol, sourcePrice, anchorPrice);
+            uint reporterPrice = priceData.getPrice(reporter, tokenConfig.openOracleKey);
+            uint anchorPrice = getAnchorInUsd(tokenConfig, usdcPrice);
+            
+            uint anchorRatio = mul(anchorPrice, 100e16) / reporterPrice;
+            bool withinAnchor = anchorRatio <= upperBoundAnchorRatio && anchorRatio >= lowerBoundAnchorRatio;
+
+            if (withinAnchor || anchorBreaker) {
+                // only update and emit event if value changes
+                if (_prices[tokenConfig.openOracleKey] != reporterPrice) {
+                    _prices[tokenConfig.openOracleKey] = reporterPrice;
+                    emit PriceUpdated(tokenConfig.openOracleKey, reporterPrice);
                 }
+            } else {
+                emit PriceGuarded(tokenConfig.openOracleKey, reporterPrice, anchorPrice);
             }
         }
     }
     /**
      * @notice Returns price denominated in USD, with 6 decimals
-     * @dev If price was posted by source, return it. Otherwise, return anchor price converted through source ETH price.
+     * @dev If price was posted by reporter, return it. Otherwise, return anchor price converted through reporter ETH price.
      */
-    function prices(string calldata symbol) external view returns (uint256) {
-        uint256 price = _prices[symbol];
+    function prices(string calldata symbol) external view returns (uint) {
+        CTokenMetadata memory tokenConfig = getCTokenConfig(symbol);
 
-        if (price != 0) {
-            return price;
-        } else {
-            uint256 usdPerEth = _prices["ETH"];
-            uint256 ethPerToken = readAnchor(getCTokenAddress(symbol));
+        if (tokenConfig.priceSource == PriceSource.REPORTER) return _prices[symbol];
+        if (tokenConfig.priceSource == PriceSource.FIXED_USD) return tokenConfig.fixedReporterPrice;
+        if (tokenConfig.priceSource == PriceSource.ANCHOR) {
+            uint usdPerEth = _prices["ETH"];
+            require(usdPerEth > 0, "eth price not set, cannot convert eth to dollars");
 
-            // ethPerToken has 18 decimals since the usdt, usdc, wbtc tokens hit
-            // usdPerEth has 6 decimals
-            // scaling by 1e18 and dividing leaves 1e6, as desired
-            return mul(usdPerEth, 1e18) / ethPerToken;
+            uint ethPerToken = readAnchor(tokenConfig);
+            return mul(usdPerEth, ethPerToken) / tokenConfig.baseUnit;
         }
     }
 
     /**
      * @dev fetch price in eth from proxy and convert to usd price using anchor usdc price.
-     * @dev Anchor usdc price has 30 decimals, and anchor general price has 18 decimals, so multiplying 1e18 by 1e18 and dividing by 1e30 yields 1e6
+     * @dev Anchor price has 36 - underlying decimals, so scale back up to 36 decimals before dividing by by usdc price  (30 decimals), yielding 6 decimal usd price
      */
-    function getAnchorInUsd(address tokenAddress, uint256 usdcPrice) public view returns (uint256) {
-        // TODO: can get rid of trhis if handle decimals more elegantly
-        if ( tokenAddress == cUsdcAddress || tokenAddress == cUsdtAddress )  {
-            // hard code to 1 dollar
-            return oneDollar;
+    function getAnchorInUsd(address cToken, uint ethPerUsdc) public view returns (uint) {
+        CTokenMetadata memory tokenConfig = getCTokenConfig(cToken);
+        return getAnchorInUsd(tokenConfig, ethPerUsdc);
+    }
+
+    function getAnchorInUsd(CTokenMetadata memory tokenConfig, uint ethPerUsdc) internal view returns (uint) {
+        if (tokenConfig.anchorSource == AnchorSource.FIXED_USD) {
+            return tokenConfig.fixedAnchorPrice;
         }
 
-        uint priceInEth = readAnchor(tokenAddress);
-        uint additionalScale;
-        if ( tokenAddress == cWbtcAddress ){
-            // wbtc proxy price is scaled 1e(36 - 8) = 1e28, so we need 8 more to get to 36
-            additionalScale = 1e8;
-        } else {
-            // all other tokens are scaled 1e18, so we need 18 more to get to 36
-            additionalScale = 1e18;
-        }
+        uint ethPerToken = readAnchor(tokenConfig);
 
-        // usdcPrice has 30 decimals, so final result has 6
-        return mul(priceInEth, additionalScale) / usdcPrice;
+        return mul(ethPerToken, tokenConfig.baseUnit) / ethPerUsdc;
     }
 
     /**
@@ -190,87 +172,81 @@ contract AnchoredView is SymbolConfiguration {
      * @param cToken The cToken address for price retrieval
      * @return The price for the given cToken address
      */
-    function getUnderlyingPrice(address cToken) external view returns (uint256) {
-        if (breaker == true) {
-            return readAnchor(cToken);
+    function getUnderlyingPrice(address cToken) public view returns (uint) {
+        CTokenMetadata memory tokenConfig = getCTokenConfig(cToken);
+        if (reporterBreaker == true) {
+            return readAnchor(tokenConfig);
         }
 
-        uint256 usdPerToken = _prices[getOracleKey(cToken)];
+        if (tokenConfig.priceSource == PriceSource.FIXED_USD) {
+            uint usdPerToken = tokenConfig.fixedReporterPrice;
+            return mul(usdPerToken, 1e30) / tokenConfig.baseUnit;
+        }
 
-        if ( usdPerToken == 0 ) {
-            return readAnchor(cToken);
-        } else {
-            uint256 usdPerEth = _prices["ETH"];
-            uint256 ethPerToken = mul(usdPerToken, 1e6) / usdPerEth;
-            uint256 additionalScale = getAdditionalScale(cToken);
+        if (tokenConfig.priceSource == PriceSource.REPORTER) {
+            uint usdPerToken = _prices[tokenConfig.openOracleKey];
+            return mul(usdPerToken, 1e30) / tokenConfig.baseUnit;
+        }
 
-            return mul(ethPerToken, additionalScale);
+        if (tokenConfig.priceSource == PriceSource.ANCHOR) {
+            // convert anchor price to usd, via reporter eth price
+            uint usdPerEth = _prices["ETH"];
+            require(usdPerEth != 0, "no reporter price for usd/eth exists, cannot convert anchor price to usd terms");
+
+            // factoring out extra 6 decimals from reporter eth price brings us back to decimals given by anchor
+            uint ethPerToken = readAnchor(tokenConfig);
+            return mul(usdPerEth, ethPerToken) / 1e6;
         }
     }
 
     /**
      * @notice Get the underlying price of a listed cToken asset
-     * @param cTokenAddress The cToken to get the underlying price of
+     * @param cToken The cToken to get the underlying price of
      * @return The underlying asset price mantissa (scaled by 1e18)
      */
-    function readAnchor(address cTokenAddress) public view returns (uint) {
-        if (cTokenAddress == cEthAddress) {
-            // ether always worth 1
-            return 1e18;
-        }
-
-        if (cTokenAddress == cUsdcAddress || cTokenAddress == cUsdtAddress) {
-            return anchor.assetPrices(usdcOracleKey);
-        }
-
-        if (cTokenAddress == cDaiAddress) {
-            return anchor.assetPrices(daiOracleKey);
-        }
-
-        if (cTokenAddress == cSaiAddress) {
-            return saiPrice;
-        }
-
-        // otherwise just read from v1 oracle
-        address underlying = CErc20(cTokenAddress).underlying();
-        return anchor.assetPrices(underlying);
+    function readAnchor(address cToken) public view returns (uint) {
+        return readAnchor(getCTokenConfig(cToken));
     }
 
-    /// @notice invalidate the source, and fall back to using anchor directly in all cases
+    function readAnchor(CTokenMetadata memory tokenConfig) internal view returns (uint) {
+        if (tokenConfig.anchorSource == AnchorSource.FIXED_ETH) return tokenConfig.fixedAnchorPrice;
+
+        return anchor.assetPrices(tokenConfig.anchorOracleKey);
+    }
+
+    /// @notice invalidate the reporter, and fall back to using anchor directly in all cases
     function invalidate(bytes memory message, bytes memory signature) public {
         (string memory decoded_message, ) = abi.decode(message, (string, address));
         require(keccak256(abi.encodePacked(decoded_message)) == keccak256(abi.encodePacked("rotate")), "invalid message must be 'rotate'");
-        require(priceData.source(message, signature) == source, "invalidation message must come from the reporter");
+        require(priceData.source(message, signature) == reporter, "invalidation message must come from the reporter");
 
-        breaker = true;
-        emit SourceInvalidated(source);
+        reporterBreaker = true;
+        emit ReporterInvalidated(reporter);
     }
 
-    /// @notice invalidate the anchor, and fall back to using source without anchor
+    /// @notice invalidate the anchor, and fall back to using reporter without anchor
 
     /// @dev determine if anchor is stale by checking when usdc was last updated
-    // @dev all anchor prices are converted through usdc price, so if it is stale they are all stale
-    function cutAnchor() public {
-        (uint latestUsdcAnchorPeriod,) = anchor.anchors(usdcOracleKey);
+    /// @dev all anchor prices are converted through usdc price, so if it is stale they are all stale
+    function cutAnchor() external {
+        AnchorOracle.Anchor memory latestUsdcAnchor = anchor.anchors(cUsdcAnchorKey);
 
-        uint usdcAnchorBlockNumber = mul(latestUsdcAnchorPeriod, anchor.numBlocksPerPeriod());
+        uint usdcAnchorBlockNumber = mul(latestUsdcAnchor.period, anchor.numBlocksPerPeriod());
         uint blocksSinceUpdate = block.number - usdcAnchorBlockNumber;
 
         // one day in 15 second blocks without an update
-        if (blocksSinceUpdate > 5760) {
-            anchored = false;
+        if (blocksSinceUpdate > blocksInADay) {
+            anchorBreaker = true;
             emit AnchorCut(address(anchor));
         }
     }
 
 
     // @notice overflow proof multiplication
-    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-        if (a == 0) {
-            return 0;
-        }
+    function mul(uint a, uint b) internal pure returns (uint) {
+        if (a == 0) return 0;
 
-        uint256 c = a * b;
+        uint c = a * b;
         require(c / a == b, "multiplication overflow");
 
         return c;

--- a/contracts/AnchoredView/AnchoredView.sol
+++ b/contracts/AnchoredView/AnchoredView.sol
@@ -1,0 +1,278 @@
+pragma solidity ^0.6.6;
+pragma experimental ABIEncoderV2;
+
+import "./SymbolConfiguration.sol";
+import "../OpenOraclePriceData.sol";
+
+interface CErc20 {
+    function underlying() external view returns (address);
+}
+
+interface AnchorOracle {
+    function numBlocksPerPeriod() external view returns (uint); // approximately 1 hour: 60 seconds/minute * 60 minutes/hour * 1 block/15 seconds
+
+    function assetPrices(address asset) external view returns (uint);
+
+
+    /* struct Anchor { */
+    /*     // floor(block.number / numBlocksPerPeriod) + 1 */
+    /*     uint period; */
+
+    /*     // Price in ETH, scaled by 10**18 */
+    /*     uint priceMantissa; */
+    /* } */
+    function anchors(address asset) external view returns (uint, uint);
+}
+
+
+/**
+ * @notice Price feed conforming to Price Oracle Proxy interface.
+ * @dev Use a single open oracle reporter and anchored to and falling back to the Compound v2 oracle system.
+ * @author Compound Labs, Inc.
+ */
+contract AnchoredView is SymbolConfiguration {
+    /// @notice The mapping of posted by source prices per symbol
+    mapping(string => uint256) public _prices;
+
+    /// @notice circuit breaker for using anchor price oracle directly
+    bool public breaker;
+
+    /// @notice circuit breaker for using source price without anchor
+    bool public anchored = true;
+
+    /// @notice the Open Oracle Reporter price source
+    address public immutable source;
+
+    /// @notice the anchor oracle ( Compouni Oracle V1 )
+    AnchorOracle public immutable anchor;
+
+    /// @notice the Open Oracle Price Data contract
+    OpenOraclePriceData public immutable priceData;
+
+    /// @notice The highest ratio of the new median price to the anchor price that will still trigger the median price to be updated
+    uint256 immutable upperBoundAnchorRatio;
+
+    /// @notice The lowest ratio of the new median price to the anchor price that will still trigger the median price to be updated
+    uint256 immutable lowerBoundAnchorRatio;
+
+    /// @notice standard amount for the Dollar
+    uint256 constant oneDollar = 1e6;
+
+    /// @notice The event emitted when the median price is updated
+    event PriceUpdated(string symbol, uint256 price);
+
+    /// @notice The event emitted when new prices are posted but the stored price is not updated due to the anchor
+    event PriceGuarded(string symbol, uint256 source, uint256 anchor);
+
+    /// @notice The event emitted when source invalidates itself
+    event SourceInvalidated(address source);
+
+    /// @notice The event emitted when the anchor is cut for staleness
+    event AnchorCut(address anchor);
+
+    /**
+     * @param data_ Address of the Oracle Data contract
+     * @param source_ The reporter address whose price will be used if it matches the anchor
+     * @param anchor_ The PriceOracleProxy that will be used to verify source price, or serve prices not given by the source
+     * @param anchorToleranceMantissa_ The tolerance allowed between the anchor and median. A tolerance of 10e16 means a new median that is 10% off from the anchor will still be saved
+     * @param tokens_ The CTokens struct that contains addresses for CToken contracts
+     */
+    constructor(OpenOraclePriceData data_,
+                address source_,
+                AnchorOracle anchor_,
+                uint anchorToleranceMantissa_,
+                CTokens memory tokens_) SymbolConfiguration(tokens_) public {
+        source = source_;
+        anchor = anchor_;
+        priceData = data_;
+
+        require(anchorToleranceMantissa_ < 100e16, "Anchor Tolerance is too high");
+        upperBoundAnchorRatio = 100e16 + anchorToleranceMantissa_;
+        lowerBoundAnchorRatio = 100e16 - anchorToleranceMantissa_;
+
+        _prices["USDC"] = oneDollar;
+        _prices["USDT"] = oneDollar;
+    }
+
+    /**
+     * @notice Post open oracle source prices, and recalculate stored price by comparing to anchor
+     * @dev We let anyone pay to post anything, but only prices from configured source will be stored in the view
+     * @param messages The messages to post to the oracle
+     * @param signatures The signatures for the corresponding messages
+     * @param symbols The symbols to compare to anchor for authoritative reading
+     */
+    function postPrices(bytes[] calldata messages, bytes[] calldata signatures, string[] calldata symbols) external {
+        require(messages.length == signatures.length, "messages and signatures must be 1:1");
+
+        // Save the prices
+        for (uint i = 0; i < messages.length; i++) {
+            priceData.put(messages[i], signatures[i]);
+        }
+
+        // load usdc for using in loop to convert anchor prices to dollars
+        uint256 usdcPrice = readAnchor(cUsdcAddress);
+
+        // Try to update the view storage
+        for (uint i = 0; i < symbols.length; i++) {
+            string memory symbol = symbols[i];
+            address tokenAddress = getCTokenAddress(symbol);
+            uint256 sourcePrice = priceData.getPrice(source, symbol);
+            uint256 anchorPrice = getAnchorInUsd(tokenAddress, usdcPrice);
+
+            if (anchorPrice == 0 || tokenAddress == cUsdcAddress || tokenAddress == cUsdtAddress) {
+                emit PriceGuarded(symbol, sourcePrice, anchorPrice);
+            } else {
+                uint256 anchorRatioMantissa = mul(sourcePrice, 100e16) / anchorPrice;
+                // Only update the view's price if the source price is within a bound
+                if (anchorRatioMantissa <= upperBoundAnchorRatio && anchorRatioMantissa >= lowerBoundAnchorRatio) {
+                    // only update and emit event if value changes
+                    if (_prices[symbol] != sourcePrice) {
+                        _prices[symbol] = sourcePrice;
+                        emit PriceUpdated(symbol, sourcePrice);
+                    }
+                } else if (!anchored) {
+                    _prices[symbol] = sourcePrice;
+                    emit PriceUpdated(symbol, sourcePrice);
+                } else {
+                    emit PriceGuarded(symbol, sourcePrice, anchorPrice);
+                }
+            }
+        }
+    }
+    /**
+     * @notice Returns price denominated in USD, with 6 decimals
+     * @dev If price was posted by source, return it. Otherwise, return anchor price converted through source ETH price.
+     */
+    function prices(string calldata symbol) external view returns (uint256) {
+        uint256 price = _prices[symbol];
+
+        if (price != 0) {
+            return price;
+        } else {
+            uint256 usdPerEth = _prices["ETH"];
+            uint256 ethPerToken = readAnchor(getCTokenAddress(symbol));
+
+            // ethPerToken has 18 decimals since the usdt, usdc, wbtc tokens hit
+            // usdPerEth has 6 decimals
+            // scaling by 1e18 and dividing leaves 1e6, as desired
+            return mul(usdPerEth, 1e18) / ethPerToken;
+        }
+    }
+
+    /**
+     * @dev fetch price in eth from proxy and convert to usd price using anchor usdc price.
+     * @dev Anchor usdc price has 30 decimals, and anchor general price has 18 decimals, so multiplying 1e18 by 1e18 and dividing by 1e30 yields 1e6
+     */
+    function getAnchorInUsd(address tokenAddress, uint256 usdcPrice) public view returns (uint256) {
+        // TODO: can get rid of trhis if handle decimals more elegantly
+        if ( tokenAddress == cUsdcAddress || tokenAddress == cUsdtAddress )  {
+            // hard code to 1 dollar
+            return oneDollar;
+        }
+
+        uint priceInEth = readAnchor(tokenAddress);
+        uint additionalScale;
+        if ( tokenAddress == cWbtcAddress ){
+            // wbtc proxy price is scaled 1e(36 - 8) = 1e28, so we need 8 more to get to 36
+            additionalScale = 1e8;
+        } else {
+            // all other tokens are scaled 1e18, so we need 18 more to get to 36
+            additionalScale = 1e18;
+        }
+
+        // usdcPrice has 30 decimals, so final result has 6
+        return mul(priceInEth, additionalScale) / usdcPrice;
+    }
+
+    /**
+     * @notice Implements the method of the PriceOracle interface of Compound v2 and returns returns the Eth price for an asset.
+     * @dev converts from 1e6 decimals of Open Oracle to 1e(36 - underlyingDecimals) of PriceOracleProxy
+     * @param cToken The cToken address for price retrieval
+     * @return The price for the given cToken address
+     */
+    function getUnderlyingPrice(address cToken) external view returns (uint256) {
+        if (breaker == true) {
+            return readAnchor(cToken);
+        }
+
+        uint256 usdPerToken = _prices[getOracleKey(cToken)];
+
+        if ( usdPerToken == 0 ) {
+            return readAnchor(cToken);
+        } else {
+            uint256 usdPerEth = _prices["ETH"];
+            uint256 ethPerToken = mul(usdPerToken, 1e6) / usdPerEth;
+            uint256 additionalScale = getAdditionalScale(cToken);
+
+            return mul(ethPerToken, additionalScale);
+        }
+    }
+
+    /**
+     * @notice Get the underlying price of a listed cToken asset
+     * @param cTokenAddress The cToken to get the underlying price of
+     * @return The underlying asset price mantissa (scaled by 1e18)
+     */
+    function readAnchor(address cTokenAddress) public view returns (uint) {
+        if (cTokenAddress == cEthAddress) {
+            // ether always worth 1
+            return 1e18;
+        }
+
+        if (cTokenAddress == cUsdcAddress || cTokenAddress == cUsdtAddress) {
+            return anchor.assetPrices(usdcOracleKey);
+        }
+
+        if (cTokenAddress == cDaiAddress) {
+            return anchor.assetPrices(daiOracleKey);
+        }
+
+        if (cTokenAddress == cSaiAddress) {
+            return saiPrice;
+        }
+
+        // otherwise just read from v1 oracle
+        address underlying = CErc20(cTokenAddress).underlying();
+        return anchor.assetPrices(underlying);
+    }
+
+    /// @notice invalidate the source, and fall back to using anchor directly in all cases
+    function invalidate(bytes memory message, bytes memory signature) public {
+        (string memory decoded_message, ) = abi.decode(message, (string, address));
+        require(keccak256(abi.encodePacked(decoded_message)) == keccak256(abi.encodePacked("rotate")), "invalid message must be 'rotate'");
+        require(priceData.source(message, signature) == source, "invalidation message must come from the reporter");
+
+        breaker = true;
+        emit SourceInvalidated(source);
+    }
+
+    /// @notice invalidate the anchor, and fall back to using source without anchor
+
+    /// @dev determine if anchor is stale by checking when usdc was last updated
+    // @dev all anchor prices are converted through usdc price, so if it is stale they are all stale
+    function cutAnchor() public {
+        (uint latestUsdcAnchorPeriod,) = anchor.anchors(usdcOracleKey);
+
+        uint usdcAnchorBlockNumber = mul(latestUsdcAnchorPeriod, anchor.numBlocksPerPeriod());
+        uint blocksSinceUpdate = block.number - usdcAnchorBlockNumber;
+
+        // one day in 15 second blocks without an update
+        if (blocksSinceUpdate > 5760) {
+            anchored = false;
+            emit AnchorCut(address(anchor));
+        }
+    }
+
+
+    // @notice overflow proof multiplication
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "multiplication overflow");
+
+        return c;
+    }
+}

--- a/contracts/AnchoredView/SymbolConfiguration.sol
+++ b/contracts/AnchoredView/SymbolConfiguration.sol
@@ -1,0 +1,119 @@
+pragma solidity ^0.6.6;
+pragma experimental ABIEncoderV2;
+
+// verbose configuration of anchored view, transforming
+// address to symbols and such
+contract SymbolConfiguration {
+    /// @notice Handpicked key for USDC
+    address public constant usdcOracleKey = address(1);
+
+    /// @notice Handpicked key for DAI
+    address public constant daiOracleKey = address(2);
+
+    /// @notice Frozen SAI price in ETH
+    uint public saiPrice = 1e18;
+
+    /// @notice The CToken contracts addresses
+    struct CTokens {
+        address cEthAddress;
+        address cUsdcAddress;
+        address cDaiAddress;
+        address cRepAddress;
+        address cWbtcAddress;
+        address cBatAddress;
+        address cZrxAddress;
+        address cSaiAddress;
+        address cUsdtAddress;
+    }
+
+    /// @notice The binary representation for token symbols, used for string comparison
+    bytes32 constant symbolEth = keccak256(abi.encodePacked("ETH"));
+    bytes32 constant symbolUsdc = keccak256(abi.encodePacked("USDC"));
+    bytes32 constant symbolDai = keccak256(abi.encodePacked("DAI"));
+    bytes32 constant symbolRep = keccak256(abi.encodePacked("REP"));
+    bytes32 constant symbolWbtc = keccak256(abi.encodePacked("BTC"));
+    bytes32 constant symbolBat = keccak256(abi.encodePacked("BAT"));
+    bytes32 constant symbolZrx = keccak256(abi.encodePacked("ZRX"));
+    bytes32 constant symbolSai = keccak256(abi.encodePacked("SAI"));
+    bytes32 constant symbolUsdt = keccak256(abi.encodePacked("USDT"));
+
+    /// @notice Address of the cToken contracts
+    ///  @dev must be updated to list a new token
+    address public immutable cEthAddress;
+    address public immutable cUsdcAddress;
+    address public immutable cDaiAddress;
+    address public immutable cRepAddress;
+    address public immutable cWbtcAddress;
+    address public immutable cBatAddress;
+    address public immutable cZrxAddress;
+    address public immutable cSaiAddress;
+    address public immutable cUsdtAddress;
+
+    /**
+     * @param tokens_ The CTokens struct that contains addresses for CToken contracts
+     */
+    constructor(CTokens memory tokens_) public {
+        cEthAddress = tokens_.cEthAddress;
+        cUsdcAddress = tokens_.cUsdcAddress;
+        cDaiAddress = tokens_.cDaiAddress;
+        cRepAddress = tokens_.cRepAddress;
+        cWbtcAddress = tokens_.cWbtcAddress;
+        cBatAddress = tokens_.cBatAddress;
+        cZrxAddress = tokens_.cZrxAddress;
+        cSaiAddress = tokens_.cSaiAddress;
+        cUsdtAddress = tokens_.cUsdtAddress;
+    }
+
+    /**
+     * comptroller expects price to have 18 decimals,
+     * additionally upscaled by 1e18 - underlyingdecimals
+     * base decimals is 1e6, so start by addint twelve
+     */
+    function getAdditionalScale(address cToken) public view returns (uint256) {
+        // total scale 1e30
+        if (cToken == cUsdcAddress) return 1e24;
+        if (cToken == cUsdtAddress) return 1e24;
+        // total scale 1e28
+        if (cToken == cWbtcAddress) return 1e22;
+        // total scale 1e18
+        if (cToken == cEthAddress) return 1e12;
+        revert("Requested additional scale for token served by proxy");
+    }
+
+    /**
+     * @notice Returns the cToken address for symbol
+     * @param symbol The symbol to map to cToken address
+     * @return The cToken address for the given symbol
+     */
+    function getCTokenAddress(string memory symbol) public view returns (address) {
+        bytes32 symbolHash = keccak256(abi.encodePacked(symbol));
+        if (symbolHash == symbolEth) return cEthAddress;
+        if (symbolHash == symbolUsdc) return cUsdcAddress;
+        if (symbolHash == symbolDai) return cDaiAddress;
+        if (symbolHash == symbolRep) return cRepAddress;
+        if (symbolHash == symbolWbtc) return cWbtcAddress;
+        if (symbolHash == symbolBat) return cBatAddress;
+        if (symbolHash == symbolZrx) return cZrxAddress;
+        if (symbolHash == symbolSai) return cSaiAddress;
+        if (symbolHash == symbolUsdt) return cUsdtAddress;
+        revert("Unknown token symbol");
+    }
+
+    /**
+     * @notice Returns the symbol for cToken address
+     * @param cToken The cToken address to map to symbol
+     * @return The symbol for the given cToken address
+     */
+    function getOracleKey(address cToken) public view returns (string memory) {
+        if (cToken == cEthAddress) return "ETH";
+        if (cToken == cUsdcAddress) return "USDC";
+        if (cToken == cDaiAddress) return "DAI";
+        if (cToken == cRepAddress) return "REP";
+        if (cToken == cWbtcAddress) return "BTC";
+        if (cToken == cBatAddress) return "BAT";
+        if (cToken == cZrxAddress) return "ZRX";
+        if (cToken == cSaiAddress) return "SAI";
+        if (cToken == cUsdtAddress) return "USDT";
+        revert("Unknown token address");
+    }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "deploy": "npx saddle deploy"
   },
   "resolutions": {
+    "**/ganache-core": "https://github.com/compound-finance/ganache-core.git#compound",
     "scrypt.js": "https://registry.npmjs.org/@compound-finance/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz"
   }
 }

--- a/saddle.config.js
+++ b/saddle.config.js
@@ -3,7 +3,7 @@ module.exports = {
   // solc: "solc",                                         // Solc command to run
   // solc_args: [],                                        // Extra solc args
   build_dir: process.env['SADDLE_BUILD'] || ".build",      // Directory to place built contracts
-  contracts: process.env['SADDLE_CONTRACTS'] || "contracts/*.sol tests/contracts/*.sol",  // Glob to match contract files
+  contracts: process.env['SADDLE_CONTRACTS'] || "contracts/*.sol contracts/**/*.sol tests/contracts/*.sol",  // Glob to match contract files
   tests: ['**/tests/*Test.js'],                         // Glob to match test files
   networks: {                                           // Define configuration for each network
     development: {
@@ -35,7 +35,7 @@ module.exports = {
         { env: "PROVIDER" },
         {
           ganache: {
-            gasLimit: 10000000
+            gasLimit: 80000000
           }
         },                                  // In test mode, connect to a new ganache provider. Any options will be passed to ganache
       ],

--- a/tests/AnchoredViewTest.js
+++ b/tests/AnchoredViewTest.js
@@ -1,0 +1,488 @@
+const { encode, sign, encodeRotationMessage } = require('../sdk/javascript/.tsbuilt/reporter');
+const { time, numToBigNum, numToHex, address, sendRPC } = require('./Helpers');
+
+async function setup() {
+  const source = web3.eth.accounts.privateKeyToAccount('0x177ee777e72b8c042e05ef41d1db0f17f1fcb0e8150b37cfad6993e4373bdf10');
+
+  const underlyingAddresses = [...Array(9).keys()].map(address);
+
+  const cTokensList = await Promise.all(
+    underlyingAddresses.map((x) => {
+      return deploy('MockCToken', [x]);
+    })
+  );
+
+  const tokens = {
+    eth: underlyingAddresses[0],
+    usdc: underlyingAddresses[1],
+    dai: underlyingAddresses[2],
+    rep: underlyingAddresses[3],
+    wbtc: underlyingAddresses[4],
+    bat: underlyingAddresses[5],
+    zrx: underlyingAddresses[6],
+    sai: underlyingAddresses[7],
+    usdt: underlyingAddresses[8],
+  };
+
+  const cTokens = {
+    cEth: cTokensList[0],
+    cUsdc: cTokensList[1],
+    cDai: cTokensList[2],
+    cRep: cTokensList[3],
+    cWbtc: cTokensList[4],
+    cBat: cTokensList[5],
+    cZrx: cTokensList[6],
+    cSai: cTokensList[7],
+    cUsdt: cTokensList[8]
+};
+
+  const anchorMantissa = numToHex(1e17); //1e17 equates to 10% tolerance for median to be above or below anchor
+  const priceData = await deploy('OpenOraclePriceData', []);
+  const anchorOracle = await deploy('MockAnchorOracle');
+  const delfi = await deploy('AnchoredView', [
+    priceData._address,
+    source.address,
+    anchorOracle._address,
+    anchorMantissa,
+    {
+      cEthAddress: cTokens.cEth._address,
+      cUsdcAddress: cTokens.cUsdc._address,
+      cDaiAddress: cTokens.cDai._address,
+      cRepAddress: cTokens.cRep._address,
+      cWbtcAddress: cTokens.cWbtc._address,
+      cBatAddress: cTokens.cBat._address,
+      cZrxAddress: cTokens.cZrx._address,
+      cSaiAddress: cTokens.cSai._address,
+      cUsdtAddress: cTokens.cUsdt._address
+    }
+  ]);
+
+  async function postPrices(timestamp, prices2dArr, symbols, signer = source) {
+    const messages = [],
+          signatures = [];
+
+    prices2dArr.forEach((prices, i) => {
+      const signed = sign(
+        encode(
+          'prices',
+          timestamp,
+          prices.map(([symbol, price]) => [symbol, price])
+        ),
+        signer.privateKey
+      );
+      for (let { message, signature } of signed) {
+        messages.push(message);
+        signatures.push(signature);
+      }
+    });
+    return send(delfi, 'postPrices', [messages, signatures, symbols]);
+  }
+
+  async function getPrice(symbol) {
+    return call(delfi, 'prices', [symbol]);
+  }
+
+  async function primeAnchor() {
+    // sets up anchor for $500 eth and 10k btc
+    const usdRatio = "2000000000000000000000000000";
+    await send(anchorOracle, 'setPrice', [tokens.usdc, numToHex(usdRatio)]);
+
+    const theRatio = "200000000000000000000000000000";
+    await send(anchorOracle, 'setPrice', [tokens.wbtc, numToHex(theRatio)]);
+    await send(anchorOracle, 'setPrice', [tokens.eth, numToHex("1000000000000000000")]);
+  }
+
+  return {
+    source,
+    anchorMantissa,
+    priceData,
+    delfi,
+    anchorOracle,
+    cTokens,
+    tokens,
+    postPrices,
+    primeAnchor,
+    getPrice
+  };
+}
+
+
+describe('AnchoredPriceView', () => {
+  let source,
+      anchorMantissa,
+      priceData,
+      delfi,
+      anchorOracle,
+      cTokens,
+      tokens,
+      postPrices,
+      primeAnchor,
+      getPrice;
+
+  const timestamp = time() - 5;
+  describe('Anchoring', () => {
+    beforeEach(async done => {
+      ({
+        source,
+        anchorMantissa,
+        priceData,
+        delfi,
+        anchorOracle,
+        cTokens,
+        tokens,
+        postPrices,
+        primeAnchor,
+        getPrice
+      } = await setup());
+      await primeAnchor();
+      done();
+    });
+
+    it('posting no ETH price should guard price and not revert, returns anchor price', async () => {
+      const post1 = await postPrices(timestamp, [[['ETH', 91]]], ['ETH']);
+
+      expect(post1.events.PriceGuarded).not.toBe(undefined);
+      expect(post1.events.PricePosted).toBe(undefined);
+      expect(await call(delfi, '_prices', ['ETH'])).numEquals(0);
+    });
+
+    it('posting within anchor should update stored value', async () => {
+      const post1 = await postPrices(timestamp, [[['ETH', 492]]], ['ETH']);
+
+      expect(post1.gasUsed).toBeLessThan(253000);
+      expect(post1.events.PriceUpdated.returnValues.symbol).toBe('ETH');
+      expect(post1.events.PriceUpdated.returnValues.price).numEquals(492e6);
+      expect(await getPrice('ETH')).numEquals(492e6);
+
+      // double the dollar ratio
+      await send(anchorOracle, 'setPrice', [tokens.usdc, "4000000000000000000000000000"]);
+      const post2 = await postPrices(timestamp + 1, [[['ETH', 250]]], ['ETH']);
+      expect(post2.gasUsed).toBeLessThan(252000);
+      expect(post2.events.PriceUpdated.returnValues.symbol).toBe('ETH');
+      expect(post2.events.PriceUpdated.returnValues.price).numEquals(250e6);
+      expect(await getPrice('ETH')).numEquals(250e6);
+    });
+
+    it('should not update source price if anchor is much lower, returns anchor price', async () => {
+      const post1 = await postPrices(timestamp, [[['ETH', 1000]]], ['ETH']);
+      expect(post1.events.PriceUpdated).toBe(undefined);
+      expect(post1.events.PriceGuarded).not.toBe(undefined);
+      expect(await call(delfi, '_prices', ['ETH'])).numEquals(0);
+    });
+
+    it('should not update source price if anchor is much higher, returns anchor price', async () => {
+      const post1 = await postPrices(timestamp, [[['ETH', 116]]], ['ETH']);
+      expect(post1.events.PriceUpdated).toBe(undefined);
+      expect(post1.events.PriceGuarded).not.toBe(undefined);
+      expect(await call(delfi, '_prices', ['ETH'])).numEquals(0);
+    });
+
+    it('should updates source price if anchor is cut, even if  price outside of anchor', async () => {
+      await sendRPC(web3, 'evm_mineBlockNumber', 5760);
+      await send(delfi, 'cutAnchor', []);
+      expect(await call(delfi, 'anchored')).toEqual(false);
+
+      const post1 = await postPrices(timestamp, [[['ETH', 1000]]], ['ETH']);
+      expect(post1.events.PriceUpdated).not.toBe(undefined);
+      expect(post1.events.PriceGuarded).toBe(undefined);
+      expect(await call(delfi, '_prices', ['ETH'])).numEquals(1000e6);
+    });
+
+
+    it('posting all source for two assets should update stored values', async () => {
+      const post1 = await postPrices(timestamp,
+                                     [[['ETH', 510], ['BTC', 11000]]],
+                                     ['ETH', 'BTC']);
+      expect(post1.gasUsed).toBeLessThan(650000);
+      expect(post1.events.PriceUpdated[0].returnValues.symbol).toBe('ETH');
+      expect(post1.events.PriceUpdated[0].returnValues.price).numEquals(510e6);
+      expect(await getPrice('ETH')).numEquals(510e6);
+
+      expect(post1.events.PriceUpdated[1].returnValues.symbol).toBe('BTC');
+      expect(post1.events.PriceUpdated[1].returnValues.price).numEquals(11000e6);
+      expect(await getPrice('BTC')).numEquals(11000e6);
+    });
+
+    it('view should use most recent post from source', async () => {
+      await postPrices(
+        timestamp,
+        [
+          [['ETH', 510], ['BTC', 11000]],
+        ],
+        ['ETH', 'BTC'],
+        source
+      );
+      const post2 = await postPrices(
+        timestamp + 1,
+        [
+          [['ETH', 502], ['BTC', 10008]],
+        ],
+        ['ETH', 'BTC'],
+        source
+      );
+
+      expect(post2.events.PriceUpdated[0].returnValues.price).numEquals(502e6);
+      expect(await getPrice('ETH')).numEquals(502e6);
+
+      expect(post2.events.PriceUpdated[1].returnValues.price).numEquals(10008e6);
+      expect(await getPrice('BTC')).numEquals(10008e6);
+    });
+
+    it('should revert on posting invalid message', async () => {
+      await expect(
+        send(delfi, 'postPrices', [['0xabc'], ['0x123'], []], { gas: 5000000 })
+      ).rejects.toRevert();
+    });
+
+    it('posting from non-source should not change median or emit event', async () => {
+      await postPrices(timestamp, [[['ETH', 500]]], ['ETH']);
+
+      let nonSource = web3.eth.accounts.privateKeyToAccount('0x666ee777e72b8c042e05ef41d1db0f17f1fcb0e8150b37cfad6993e4373bdf10');
+
+      const post1 = await postPrices(timestamp + 1,
+                                     [[['ETH', 595]]],
+                                     ['ETH'],
+                                     nonSource);
+
+      expect(post1.events.PriceGuarded).toBe(undefined);
+      expect(post1.events.PriceUpdated).toBe(undefined);
+      expect(await getPrice('ETH')).numEquals(500e6);
+    });
+  });
+
+  describe("getAnchorInUsd", () => {
+    beforeEach(async () => {
+      ({delfi, anchorOracle, cTokens} = await setup());
+    });
+
+    it("returns one with 6 decimals when given usd or usdt", async () => {
+
+      let usdcPrice = "5812601720530109000000000000";
+      const converted_usdc_price = await call(delfi, 'getAnchorInUsd', [cTokens.cUsdc._address, usdcPrice]);
+      expect(converted_usdc_price).toEqual(1e6.toString());
+
+      const converted_usdt_price = await call(delfi, 'getAnchorInUsd', [cTokens.cUsdt._address, usdcPrice]);
+      expect(converted_usdt_price).toEqual(1e6.toString());
+
+    });
+
+    it("converts eth price through proxy usdc, with 6 decimals", async () => {
+      await send(anchorOracle, 'setPrice', [cTokens.cEth._address, numToHex(1e18)]);
+      // ~ $172 eth
+      let usdcPrice = "5812601720530109000000000000";
+      const converted_eth_price = await call(delfi, 'getAnchorInUsd', [cTokens.cEth._address, usdcPrice]);
+      expect(converted_eth_price).toEqual(172.04e6.toString());
+    });
+
+    // [open oracle symbol, proxy price in ether, open oracle price in usd]
+    [
+      ["ETH", 1e18, 172.04e6],
+      ["SAI", 5905879257418508, 1.016047e6],
+      ["DAI", 5905879257418508, 1.016047e6],
+
+      ["BAT", 931592500000000, 0.160271e6],
+      ["REP", 56128970000000000, 9.656427e6],
+      ["ZRX", 985525000000000, 0.169549e6],
+      ["BTC", "399920015996800660000000000000", 6880.223955e6] // 8 decimals underlying -> 10 extra decimals on proxy 
+    ].forEach(([openOracleKey, proxyPrice, expectedOpenOraclePrice]) => {
+      it(`converts  ${openOracleKey} price through proxy usdc, with 6 decimals`, async () => {
+        // TODO: fix sai price test after SAI Global Settlement
+        let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
+        await send(anchorOracle, 'setUnderlyingPrice', [tokenAddress, numToHex(proxyPrice)]);
+        // ~ $172 eth
+        let usdcPrice = "5812601720530109000000000000";
+        const converted_price = await call(delfi, 'getAnchorInUsd', [tokenAddress, usdcPrice]);
+        expect(converted_price).toEqual(expectedOpenOraclePrice.toString());
+      });
+    });
+
+  });
+
+  describe("getUnderlyingPrice", () => {
+    beforeEach(async () => {
+      ( {
+        delfi,
+        anchorOracle,
+        postPrices,
+        primeAnchor,
+        cTokens,
+        source
+      } = await setup() );
+
+      await primeAnchor();
+      await postPrices(
+        timestamp,
+        [[['ETH', 500], ['BTC', 11000]]],
+        ['ETH', 'BTC']);
+    });
+
+
+    ["USDC", "USDT"].forEach((openOracleKey) => {
+      it(`returns 1 converted to ETH through source ETH with 18 + 12 decimals for ${openOracleKey}`, async () => {
+        let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
+        const underlying_price = await call(delfi, 'getUnderlyingPrice', [tokenAddress]);
+
+        expect(underlying_price).toEqual("2000000000000000000000000000");
+      });
+    });
+
+
+    it("returns source price converted to ETH with 18 + 10 decimals for BTC", async () => {
+      let tokenAddress = await call(delfi, 'getCTokenAddress', ["BTC"]);
+      const underlying_price = await call(delfi, 'getUnderlyingPrice', [tokenAddress]);
+
+      const actualOpenOraclePrice = await call(delfi, 'prices', ["BTC"]);
+
+      expect(underlying_price).numEquals("220000000000000000000000000000");
+    });
+
+    [
+      ["ETH", 1e18, 172.04],
+    ].forEach(([openOracleKey, anchorPrice, openOraclePrice]) => {
+      it(`returns source price with 18 decimals for ${openOracleKey}`, async () => {
+        let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
+        await send(anchorOracle, 'setPrice', [tokenAddress, numToHex(anchorPrice)]);
+        const post1 = await postPrices(
+          time() - 5,
+          [[[openOracleKey, openOraclePrice]]],
+          [openOracleKey],
+          source
+        );
+
+        const underlying_price = await call(delfi, 'getUnderlyingPrice', [tokenAddress]);
+
+        expect(underlying_price).numEquals(anchorPrice);
+      });
+    });
+
+    [
+      ["SAI", 5905879257418508, 1016047],
+      ["DAI", 5905879257418508, 1016047],
+      ["BAT", 931592500000000, 160271],
+      ["REP", 56128970000000000, 9656427],
+      ["ZRX", 985525000000000, 169549]
+    ].forEach(([openOracleKey, anchorPrice, openOraclePrice]) => {
+      it(`returns anchor price for unsourced ${openOracleKey}`, async () => {
+
+        let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
+        await send(anchorOracle, 'setUnderlyingPrice', [tokenAddress, numToHex(anchorPrice)]);
+
+        const underlying_price = await call(delfi, 'getUnderlyingPrice', [tokenAddress]);
+
+
+        expect(underlying_price).numEquals(anchorPrice);
+      });
+    });
+
+      [
+        ["ETH", 1e18],
+        ["SAI", 5905879257418508],
+        ["DAI", 5905879257418508],
+        ["USDT", "5905879257418508000000000000"],
+        ["USDC", "5905879257418508000000000000"],
+        ["BAT", 931592500000000],
+        ["REP", 56128970000000000],
+        ["ZRX", 985525000000000],
+        ["BTC", "399920015996800660000000000000"] // 8 decimals underlying -> 10 extra decimals on proxy 
+      ].forEach(([openOracleKey, proxyPrice]) => {
+        it(`returns anchor price if breaker is set for ${openOracleKey}`, async () => {
+          let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
+          if (openOracleKey == "USDT") {
+            await send(anchorOracle, 'setUnderlyingPrice', [cTokens.cUsdc._address, numToHex(proxyPrice)]);
+          } else {
+            await send(anchorOracle, 'setUnderlyingPrice', [tokenAddress, numToHex(proxyPrice)]);
+          }
+
+          const rotationTarget = '0xAbcdef0123456789000000000000000000000005';
+          let encoded = encodeRotationMessage(rotationTarget);
+          const [ signed ] = sign(encoded, source.privateKey);
+
+          expect(await call(delfi, 'breaker', [])).toEqual(false);
+
+          await send(delfi, 'invalidate', [encoded, signed.signature]);
+          expect(await call(delfi, 'breaker', [])).toEqual(true);
+
+          expect(await call(delfi, 'getUnderlyingPrice', [tokenAddress])).numEquals(proxyPrice);
+      });
+    });
+  });
+
+  describe("invalidate", () => {
+    beforeEach(async () => {
+      ({
+        source,
+        priceData,
+        delfi,
+        anchorOracle,
+        cTokens,
+        postPrices
+      } = await setup());
+    });
+
+    it("reverts if given wrong message", async () => {
+      const rotationTarget = '0xAbcdef0123456789000000000000000000000005';
+      let encoded = web3.eth.abi.encodeParameters(['string', 'address'], ['stay still', rotationTarget]);
+      const [ signed ] = sign(encoded, source.privateKey);
+
+      await expect(
+        send(delfi, 'invalidate', [encoded, signed.signature])
+      ).rejects.toRevert("revert invalid message must be 'rotate'");
+    });
+
+    it("reverts if given wrong signature", async () => {
+      const rotationTarget = '0xAbcdef0123456789000000000000000000000005';
+      let encoded = encodeRotationMessage(rotationTarget);
+      // sign rotation message with wrong key
+      const [ signed ] = sign(encoded, '0x666ee777e72b8c042e05ef41d1db0f17f1fcb0e8150b37cfad6993e4373bdf10');
+
+      await expect(
+        send(delfi, 'invalidate', [encoded, signed.signature + "1"])
+      ).rejects.toRevert("revert invalidation message must come from the reporter");
+
+    });
+
+    it("sets fallback flag to true if passes", async () => {
+      const rotationTarget = '0xAbcdef0123456789000000000000000000000005';
+      let encoded = encodeRotationMessage(rotationTarget);
+      // sign rotation message with wrong key
+      const [ signed ] = sign(encoded, source.privateKey);
+      expect(await call(delfi, 'breaker', [])).toEqual(false);
+      await send(delfi, 'invalidate', [encoded, signed.signature]);
+
+      expect(await call(delfi, 'breaker', [])).toEqual(true);
+    });
+  });
+
+  describe("cutAnchor", () => {
+    beforeEach(async () => {
+      ({
+        delfi,
+        anchorOracle,
+        tokens
+      } = await setup());
+    });
+
+
+    it("cuts anchor if anchor is stale", async () => {
+      await sendRPC(web3, 'evm_mineBlockNumber', 17757);
+      let blocksPerPeriod =  await call(anchorOracle, 'numBlocksPerPeriod', []);
+      await send(anchorOracle, 'setAnchorPeriod', [tokens.usdc, 12000 /  blocksPerPeriod]);
+
+      var cut = await send(delfi, 'cutAnchor', []);
+      expect(await call(delfi, 'anchored')).toEqual(true);
+
+      // one more block has passed, so now cuttable
+      // now on block 17761 aka 5761 blocks past last anchor
+      cut = await send(delfi, 'cutAnchor', []);
+      expect(await call(delfi, 'anchored')).toEqual(false);
+      expect(cut.events.AnchorCut.returnValues.anchor).toEqual(anchorOracle._address);
+    });
+
+    it("no op if anchor is up to date", async () => {
+      await sendRPC(web3, 'evm_mineBlockNumber', [0]);
+      let cut = await send(delfi, 'cutAnchor', []);
+      expect(await call(delfi, 'anchored')).toEqual(true);
+    });
+
+  });
+});

--- a/tests/AnchoredViewTest.js
+++ b/tests/AnchoredViewTest.js
@@ -82,9 +82,8 @@ async function setup() {
     return call(delfi, 'prices', [symbol]);
   }
 
-  async function primeAnchor() {
+  async function primeAnchor(usdRatio = "2000000000000000000000000000") {
     // sets up anchor for $500 eth and 10k btc
-    const usdRatio = "2000000000000000000000000000";
     await send(anchorOracle, 'setPrice', [tokens.usdc, numToHex(usdRatio)]);
 
     const theRatio = "200000000000000000000000000000";
@@ -138,7 +137,7 @@ describe('AnchoredPriceView', () => {
       done();
     });
 
-    it('posting no ETH price should guard price and not revert, returns anchor price', async () => {
+    it('posting no ETH price should guard price', async () => {
       const post1 = await postPrices(timestamp, [[['ETH', 91]]], ['ETH']);
 
       expect(post1.events.PriceGuarded).not.toBe(undefined);
@@ -152,7 +151,7 @@ describe('AnchoredPriceView', () => {
       expect(post1.gasUsed).toBeLessThan(253000);
       expect(post1.events.PriceUpdated.returnValues.symbol).toBe('ETH');
       expect(post1.events.PriceUpdated.returnValues.price).numEquals(492e6);
-      expect(await getPrice('ETH')).numEquals(492e6);
+      expect(await call(delfi, 'prices', ['ETH'])).numEquals(492e6);
 
       // double the dollar ratio
       await send(anchorOracle, 'setPrice', [tokens.usdc, "4000000000000000000000000000"]);
@@ -180,7 +179,7 @@ describe('AnchoredPriceView', () => {
     it('should updates source price if anchor is cut, even if  price outside of anchor', async () => {
       await sendRPC(web3, 'evm_mineBlockNumber', 5760);
       await send(delfi, 'cutAnchor', []);
-      expect(await call(delfi, 'anchored')).toEqual(false);
+      expect(await call(delfi, 'anchorBreaker')).toEqual(true);
 
       const post1 = await postPrices(timestamp, [[['ETH', 1000]]], ['ETH']);
       expect(post1.events.PriceUpdated).not.toBe(undefined);
@@ -234,6 +233,14 @@ describe('AnchoredPriceView', () => {
       ).rejects.toRevert();
     });
 
+    it('allows writing unconfigured tokens to storage, but not view', async () => {
+      await postPrices(timestamp, [[['BLETH', 500]]], ['BLETH']);
+
+      expect(await getPrice('BLETH')).numEquals(0);
+      expect(await call(priceData, 'getPrice', [source.address, 'BLETH'])).numEquals(500e6);
+    });
+
+
     it('posting from non-source should not change median or emit event', async () => {
       await postPrices(timestamp, [[['ETH', 500]]], ['ETH']);
 
@@ -248,6 +255,18 @@ describe('AnchoredPriceView', () => {
       expect(post1.events.PriceUpdated).toBe(undefined);
       expect(await getPrice('ETH')).numEquals(500e6);
     });
+
+    it('guards when posts usdc or usdt, but reads fixed price always', async () => {
+      let post1 = await postPrices(timestamp, [[['USDC', 1.01], ['USDT', 0.99] ]], ['USDC', 'USDT']);
+
+      expect(post1.events.PriceGuarded).toBe(undefined);
+      expect(post1.events.PriceUpdated[0].returnValues.symbol).toEqual('USDC');
+      expect(post1.events.PriceUpdated[0].returnValues.price).numEquals(1.01e6);
+      expect(post1.events.PriceUpdated[1].returnValues.symbol).toEqual('USDT');
+      expect(post1.events.PriceUpdated[1].returnValues.price).numEquals(0.99e6);
+      expect(await getPrice('USDC')).numEquals(1e6);
+      expect(await getPrice('USDT')).numEquals(1e6);
+    });
   });
 
   describe("getAnchorInUsd", () => {
@@ -259,6 +278,7 @@ describe('AnchoredPriceView', () => {
 
       let usdcPrice = "5812601720530109000000000000";
       const converted_usdc_price = await call(delfi, 'getAnchorInUsd', [cTokens.cUsdc._address, usdcPrice]);
+      const converted_usdc_price_p = await send(delfi, 'getAnchorInUsd', [cTokens.cUsdc._address, usdcPrice]);
       expect(converted_usdc_price).toEqual(1e6.toString());
 
       const converted_usdt_price = await call(delfi, 'getAnchorInUsd', [cTokens.cUsdt._address, usdcPrice]);
@@ -266,18 +286,10 @@ describe('AnchoredPriceView', () => {
 
     });
 
-    it("converts eth price through proxy usdc, with 6 decimals", async () => {
-      await send(anchorOracle, 'setPrice', [cTokens.cEth._address, numToHex(1e18)]);
-      // ~ $172 eth
-      let usdcPrice = "5812601720530109000000000000";
-      const converted_eth_price = await call(delfi, 'getAnchorInUsd', [cTokens.cEth._address, usdcPrice]);
-      expect(converted_eth_price).toEqual(172.04e6.toString());
-    });
-
     // [open oracle symbol, proxy price in ether, open oracle price in usd]
     [
       ["ETH", 1e18, 172.04e6],
-      ["SAI", 5905879257418508, 1.016047e6],
+      ["SAI", 5285551943761727, 0.909326e6], // sai priced at 189, so drops to 90 cents here
       ["DAI", 5905879257418508, 1.016047e6],
 
       ["BAT", 931592500000000, 0.160271e6],
@@ -309,38 +321,44 @@ describe('AnchoredPriceView', () => {
         source
       } = await setup() );
 
-      await primeAnchor();
+      // // ~ $172 eth
+      await primeAnchor("5812601720530109000000000000");
       await postPrices(
         timestamp,
-        [[['ETH', 500], ['BTC', 11000]]],
-        ['ETH', 'BTC']);
+        [[['ETH', 172.00]]],
+        ['ETH']);
     });
 
 
     ["USDC", "USDT"].forEach((openOracleKey) => {
-      it(`returns 1 converted to ETH through source ETH with 18 + 12 decimals for ${openOracleKey}`, async () => {
+      it(`returns 1 with 36 - 6 for ${openOracleKey}`, async () => {
         let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
         const underlying_price = await call(delfi, 'getUnderlyingPrice', [tokenAddress]);
 
-        expect(underlying_price).toEqual("2000000000000000000000000000");
+        expect(underlying_price).toEqual("1000000000000000000000000000000");
       });
     });
 
 
-    it("returns source price converted to ETH with 18 + 10 decimals for BTC", async () => {
+    it("returns source price with 36 - 8 decimals for BTC ", async () => {
+      await postPrices(
+        timestamp,
+        [[['BTC', 3443.00]]],
+        ['BTC']);
       let tokenAddress = await call(delfi, 'getCTokenAddress', ["BTC"]);
       const underlying_price = await call(delfi, 'getUnderlyingPrice', [tokenAddress]);
 
       const actualOpenOraclePrice = await call(delfi, 'prices', ["BTC"]);
 
-      expect(underlying_price).numEquals("220000000000000000000000000000");
+      expect(underlying_price).numEquals("34430000000000000000000000000000");
     });
 
     [
-      ["ETH", 1e18, 172.04],
+      ["ETH", 1e18, 173.04],
     ].forEach(([openOracleKey, anchorPrice, openOraclePrice]) => {
-      it(`returns source price with 18 decimals for ${openOracleKey}`, async () => {
+      it(`returns source price with 36 - 18 decimals for ${openOracleKey}`, async () => {
         let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
+        /// XXX set a usdc price so this updates
         await send(anchorOracle, 'setPrice', [tokenAddress, numToHex(anchorPrice)]);
         const post1 = await postPrices(
           time() - 5,
@@ -350,33 +368,38 @@ describe('AnchoredPriceView', () => {
         );
 
         const underlying_price = await call(delfi, 'getUnderlyingPrice', [tokenAddress]);
+        const actualOpenOraclePrice = openOraclePrice * 1e6;
 
-        expect(underlying_price).numEquals(anchorPrice);
+        expect(underlying_price).toEqual(numToBigNum(actualOpenOraclePrice).mul(numToBigNum("1000000000000")).toString(10));
       });
     });
 
     [
-      ["SAI", 5905879257418508, 1016047],
-      ["DAI", 5905879257418508, 1016047],
-      ["BAT", 931592500000000, 160271],
-      ["REP", 56128970000000000, 9656427],
-      ["ZRX", 985525000000000, 169549]
+      ["DAI", 5905879257418508, "1016047467446280116"],
+      ["BAT", 931592500000000, "160271173700000000"],
+      ["REP", 56128970000000000, "9656427998800000000"],
+      ["ZRX", 985525000000000, "169549721000000000"]
     ].forEach(([openOracleKey, anchorPrice, openOraclePrice]) => {
-      it(`returns anchor price for unsourced ${openOracleKey}`, async () => {
+      it(`returns anchor price converted to dollars with 18 decimals for ${openOracleKey} converted through open oracle eth price`, async () => {
 
         let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
         await send(anchorOracle, 'setUnderlyingPrice', [tokenAddress, numToHex(anchorPrice)]);
+        const post1 = await postPrices(
+          time() - 5,
+          [[['ETH', 172.04]]],
+          ['ETH'],
+          source
+        );
 
         const underlying_price = await call(delfi, 'getUnderlyingPrice', [tokenAddress]);
 
-
-        expect(underlying_price).numEquals(anchorPrice);
+        expect(underlying_price).toEqual(openOraclePrice);
       });
     });
 
       [
         ["ETH", 1e18],
-        ["SAI", 5905879257418508],
+        ["SAI", 5285551943761727],
         ["DAI", 5905879257418508],
         ["USDT", "5905879257418508000000000000"],
         ["USDC", "5905879257418508000000000000"],
@@ -385,7 +408,7 @@ describe('AnchoredPriceView', () => {
         ["ZRX", 985525000000000],
         ["BTC", "399920015996800660000000000000"] // 8 decimals underlying -> 10 extra decimals on proxy 
       ].forEach(([openOracleKey, proxyPrice]) => {
-        it(`returns anchor price if breaker is set for ${openOracleKey}`, async () => {
+        it(`returns anchor price if reporterBreaker is set for ${openOracleKey}`, async () => {
           let tokenAddress = await call(delfi, 'getCTokenAddress', [openOracleKey]);
           if (openOracleKey == "USDT") {
             await send(anchorOracle, 'setUnderlyingPrice', [cTokens.cUsdc._address, numToHex(proxyPrice)]);
@@ -397,10 +420,10 @@ describe('AnchoredPriceView', () => {
           let encoded = encodeRotationMessage(rotationTarget);
           const [ signed ] = sign(encoded, source.privateKey);
 
-          expect(await call(delfi, 'breaker', [])).toEqual(false);
+          expect(await call(delfi, 'reporterBreaker', [])).toEqual(false);
 
           await send(delfi, 'invalidate', [encoded, signed.signature]);
-          expect(await call(delfi, 'breaker', [])).toEqual(true);
+          expect(await call(delfi, 'reporterBreaker', [])).toEqual(true);
 
           expect(await call(delfi, 'getUnderlyingPrice', [tokenAddress])).numEquals(proxyPrice);
       });
@@ -446,10 +469,10 @@ describe('AnchoredPriceView', () => {
       let encoded = encodeRotationMessage(rotationTarget);
       // sign rotation message with wrong key
       const [ signed ] = sign(encoded, source.privateKey);
-      expect(await call(delfi, 'breaker', [])).toEqual(false);
+      expect(await call(delfi, 'reporterBreaker', [])).toEqual(false);
       await send(delfi, 'invalidate', [encoded, signed.signature]);
 
-      expect(await call(delfi, 'breaker', [])).toEqual(true);
+      expect(await call(delfi, 'reporterBreaker', [])).toEqual(true);
     });
   });
 
@@ -469,19 +492,19 @@ describe('AnchoredPriceView', () => {
       await send(anchorOracle, 'setAnchorPeriod', [tokens.usdc, 12000 /  blocksPerPeriod]);
 
       var cut = await send(delfi, 'cutAnchor', []);
-      expect(await call(delfi, 'anchored')).toEqual(true);
+      expect(await call(delfi, 'anchorBreaker')).toEqual(false);
 
       // one more block has passed, so now cuttable
       // now on block 17761 aka 5761 blocks past last anchor
       cut = await send(delfi, 'cutAnchor', []);
-      expect(await call(delfi, 'anchored')).toEqual(false);
+      expect(await call(delfi, 'anchorBreaker')).toEqual(true);
       expect(cut.events.AnchorCut.returnValues.anchor).toEqual(anchorOracle._address);
     });
 
     it("no op if anchor is up to date", async () => {
       await sendRPC(web3, 'evm_mineBlockNumber', [0]);
       let cut = await send(delfi, 'cutAnchor', []);
-      expect(await call(delfi, 'anchored')).toEqual(true);
+      expect(await call(delfi, 'anchorBreaker')).toEqual(false);
     });
 
   });

--- a/tests/Helpers.js
+++ b/tests/Helpers.js
@@ -27,7 +27,32 @@ function time(){
 	return Math.floor(new Date() / 1000);
 }
 
+function sendRPC(web3, method, params) {
+  return new Promise((resolve, reject) => {
+    if (!web3.currentProvider || typeof (web3.currentProvider) === 'string') {
+      return reject(`cannot send from currentProvider=${web3.currentProvider}`);
+    }
+
+    web3.currentProvider.send(
+      {
+        jsonrpc: '2.0',
+        method: method,
+        params: params,
+        id: new Date().getTime() // Id of the request; anything works, really
+      },
+      (err, response) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(response);
+        }
+      }
+    );
+  });
+}
+
 module.exports = {
+  sendRPC,
 	address,
 	bytes,
 	time,

--- a/tests/contracts/ProxyPriceOracle.sol
+++ b/tests/contracts/ProxyPriceOracle.sol
@@ -1,9 +1,7 @@
 pragma solidity ^0.6.6;
-import "../../contracts/AnchoredPriceView.sol";
 
-
-// @dev mock version of price oracle proxy, allowing manually setting return values
-contract ProxyPriceOracle is AnchorPriceOracle {
+// @dev mock version of v1 price oracle, allowing manually setting return values
+contract ProxyPriceOracle {
 
     mapping(address => uint256) public prices;
 
@@ -11,7 +9,43 @@ contract ProxyPriceOracle is AnchorPriceOracle {
         prices[ctoken] = price;
     }
 
-    function getUnderlyingPrice(address ctoken) override external view returns (uint) {
+    function getUnderlyingPrice(address ctoken) external view returns (uint) {
         return prices[ctoken];
+    }
+}
+
+
+contract MockAnchorOracle {
+    struct Anchor {
+        // floor(block.number / numBlocksPerPeriod) + 1
+        uint period;
+
+        // Price in ETH, scaled by 10**18
+        uint priceMantissa;
+    }
+    mapping(address => uint256) public assetPrices;
+
+    function setPrice(address asset, uint price) external {
+        assetPrices[asset] = price;
+    }
+
+    function setUnderlyingPrice(MockCToken asset, uint price) external {
+        assetPrices[asset.underlying()] = price;
+    }
+
+
+    uint public constant numBlocksPerPeriod = 240;
+
+    mapping(address => Anchor) public anchors;
+    function setAnchorPeriod(address asset, uint period) external {
+        // dont care about anchor price, only period
+        anchors[asset] = Anchor({period: period, priceMantissa: 1e18});
+    }
+}
+
+contract MockCToken {
+    address public underlying;
+    constructor(address underlying_) public {
+        underlying = underlying_;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4541,7 +4541,7 @@ functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-ganache-core@^2.5.6, ganache-core@^2.6.0:
+ganache-core@^2.5.6:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.8.0.tgz#eeadc7f7fc3a0c20d99f8f62021fb80b5a05490c"
   integrity sha512-hfXqZGJx700jJqwDHNXrU2BnPYuETn1ekm36oRHuXY3oOuJLFs5C+cFdUFaBlgUxcau1dOgZUUwKqTAy0gTA9Q==
@@ -4574,10 +4574,9 @@ ganache-core@^2.5.6, ganache-core@^2.6.0:
     ethereumjs-wallet "0.6.3"
     web3 "1.2.1"
 
-ganache-core@^2.9.1:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.9.2.tgz#1c7516f785669f35edac9ffaa40c3ece2749bf50"
-  integrity sha512-+BHzLDpickuq/f147ryoHClzSG7P9DfiOfwntEHbXFbfsLvmGCbE3TiKwwWkcVoiBdkN8ybyElWE0QoYe3/LOA==
+ganache-core@^2.6.0, ganache-core@^2.9.1, "ganache-core@https://github.com/compound-finance/ganache-core.git#compound":
+  version "2.9.1"
+  resolved "https://github.com/compound-finance/ganache-core.git#1d1610a2a0b921e2120fade845658c6238100e21"
   dependencies:
     abstract-leveldown "3.0.0"
     async "2.6.2"


### PR DESCRIPTION
note, sai tests are failing right now b/c they have a hardcoded value for sai price that will need to be set ( on May 12, allegedly ), so rather keep those tests failing 

1. Split View into two contracts, one for all the hairy config, other for the logic. 
  - Hairy config could still be untangled / verified in constructor.
2. Add cutAnchor function that checks if last v1 oracle update for usdc was over 5760 blocks in the past ( ~ 24 hours , maybe we should bump up in case of fast blocks ). If it is, don't block updates from CB.
3. Put the current proxy logic into the view, since we now must depend on v1 oracle direclty to get the time periods, might as well pull that function in