### PR TITLE
Key observations mappings off symbolHash, add event value tests

### DIFF
--- a/tests/PostRealWorldPricesTest.js
+++ b/tests/PostRealWorldPricesTest.js
@@ -17,7 +17,7 @@ async function setupTokenPairs() {
     "5820053774558372823476814618189",
   ]);
 
-  // Initialize DAI_ETH pair with values from mainnet
+  // Initialize DAI pair with values from mainnet
   const dai_eth_pair = await deploy("MockUniswapTokenPair", [
     "3435618131150076101237553",
     "15407572689721099289685",
@@ -26,7 +26,7 @@ async function setupTokenPairs() {
     "5069668089169215245120760905619375569156736",
   ]);
 
-  // Initialize REP_ETH pair with values from mainnet
+  // Initialize REP pair with values from mainnet
   const rep_eth_pair = await deploy("MockUniswapTokenPair", [
     "40867690797665090689823",
     "3089126268851209725535",
@@ -35,7 +35,7 @@ async function setupTokenPairs() {
     "315226499991023307900665225550194785606382",
   ]);
 
-  // Initialize BAT_ETH pair with values from mainnet
+  // Initialize BAT pair with values from mainnet
   const bat_eth_pair = await deploy("MockUniswapTokenPair", [
     "2809215824116494014601294",
     "3000910749924336260251",
@@ -44,7 +44,7 @@ async function setupTokenPairs() {
     "22353658718734403427774753736831427982055589"
   ]);
 
-  // Initialize ETH_ZRX pair with values from mainnet
+  // Initialize ZRX pair with values from mainnet
   // Reversed market
   const eth_zrx_pair = await deploy("MockUniswapTokenPair", [
     "259245497861929182740",
@@ -54,7 +54,7 @@ async function setupTokenPairs() {
     "30665287778536822167996154892216941694",
   ]);
 
-  // Initialize WBTC_ETH pair with values from mainnet
+  // Initialize BTC pair with values from mainnet
   const wbtc_eth_pair = await deploy("MockUniswapTokenPair", [
     "4744946699",
     "1910114633221652017296",
@@ -63,7 +63,7 @@ async function setupTokenPairs() {
     "49529064100184996951568929095",
   ]);
 
-  // Initialize COMP_ETH pair with values from mainnet
+  // Initialize COMP pair with values from mainnet
   const comp_eth_pair = await deploy("MockUniswapTokenPair", [
     "2726069269242972517844",
     "2121223809443892142647",
@@ -72,7 +72,7 @@ async function setupTokenPairs() {
     "10471832919000882624476515664573920963717"
   ])
 
-  // Initialize LINK_ETH pair with values from mainnet
+  // Initialize LINK pair with values from mainnet
   const link_eth_pair = await deploy("MockUniswapTokenPair", [
     "115522168522463195428450",
     "2448717634007234031730",
@@ -81,7 +81,7 @@ async function setupTokenPairs() {
     "1098123734917468235191126600400328121343356",
   ])
 
-  // Initialize ETH_KNC pair with values from mainnet
+  // Initialize KNC pair with values from mainnet
   // Reversed market
   const eth_knc_pair = await deploy("MockUniswapTokenPair", [
     "2071741256888346573966",
@@ -92,15 +92,15 @@ async function setupTokenPairs() {
   ])
 
   return {
-    USDC_ETH: usdc_eth_pair,
-    DAI_ETH: dai_eth_pair,
-    REP_ETH: rep_eth_pair,
-    BAT_ETH: bat_eth_pair,
-    ETH_ZRX: eth_zrx_pair,
-    WBTC_ETH: wbtc_eth_pair,
-    COMP_ETH: comp_eth_pair,
-    LINK_ETH: link_eth_pair,
-    ETH_KNC: eth_knc_pair,
+    ETH: usdc_eth_pair,
+    DAI: dai_eth_pair,
+    REP: rep_eth_pair,
+    BAT: bat_eth_pair,
+    ZRX: eth_zrx_pair,
+    BTC: wbtc_eth_pair,
+    COMP: comp_eth_pair,
+    LINK: link_eth_pair,
+    KNC: eth_knc_pair,
   }
 }
 
@@ -117,15 +117,15 @@ async function setupUniswapAnchoredView(pairs) {
   const anchorPeriod = 30 * 60;
 
   const tokenConfigs = [
-    {cToken: address(1), underlying: address(1), symbolHash: keccak256("ETH"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.USDC_ETH._address, isUniswapReversed: true},
-    {cToken: address(2), underlying: address(2), symbolHash: keccak256("DAI"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.DAI_ETH._address, isUniswapReversed: false},
-    {cToken: address(3), underlying: address(3), symbolHash: keccak256("REP"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.REP_ETH._address, isUniswapReversed: false},
-    {cToken: address(4), underlying: address(4), symbolHash: keccak256("BAT"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.BAT_ETH._address, isUniswapReversed: false},
-    {cToken: address(5), underlying: address(5), symbolHash: keccak256("ZRX"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.ETH_ZRX._address, isUniswapReversed: true},
-    {cToken: address(6), underlying: address(6), symbolHash: keccak256("BTC"), baseUnit: uint(1e8), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.WBTC_ETH._address, isUniswapReversed: false},
-    {cToken: address(7), underlying: address(7), symbolHash: keccak256("COMP"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.COMP_ETH._address, isUniswapReversed: false},
-    {cToken: address(8), underlying: address(8), symbolHash: keccak256("KNC"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.ETH_KNC._address, isUniswapReversed: true},
-    {cToken: address(9), underlying: address(9), symbolHash: keccak256("LINK"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.LINK_ETH._address, isUniswapReversed: false},
+    {cToken: address(1), underlying: address(1), symbolHash: keccak256("ETH"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.ETH._address, isUniswapReversed: true},
+    {cToken: address(2), underlying: address(2), symbolHash: keccak256("DAI"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.DAI._address, isUniswapReversed: false},
+    {cToken: address(3), underlying: address(3), symbolHash: keccak256("REP"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.REP._address, isUniswapReversed: false},
+    {cToken: address(4), underlying: address(4), symbolHash: keccak256("BAT"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.BAT._address, isUniswapReversed: false},
+    {cToken: address(5), underlying: address(5), symbolHash: keccak256("ZRX"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.ZRX._address, isUniswapReversed: true},
+    {cToken: address(6), underlying: address(6), symbolHash: keccak256("BTC"), baseUnit: uint(1e8), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.BTC._address, isUniswapReversed: false},
+    {cToken: address(7), underlying: address(7), symbolHash: keccak256("COMP"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.COMP._address, isUniswapReversed: false},
+    {cToken: address(8), underlying: address(8), symbolHash: keccak256("KNC"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.KNC._address, isUniswapReversed: true},
+    {cToken: address(9), underlying: address(9), symbolHash: keccak256("LINK"), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: pairs.LINK._address, isUniswapReversed: false},
   ];
 
   return deploy("UniswapAnchoredView", [priceData._address, reporter, anchorMantissa, anchorPeriod, tokenConfigs]);
@@ -136,7 +136,7 @@ async function setup() {
   const uniswapAnchoredView = await setupUniswapAnchoredView(pairs);
 
   function isReversedMarket(name) {
-    return name == "USDC_ETH" || name == "ETH_ZRX" || name == "ETH_KNC";
+    return name == "ETH" || name == "ZRX" || name == "KNC";
   }
 
   function fraction(numerator, denominator){
@@ -223,6 +223,8 @@ async function setup() {
 }
 
 describe("UniswapAnchoredView", () => {
+  // No data for COMP from Coinbase so far, it is not added to the oracle yet
+  const symbols = ["BTC", "ETH", "DAI", "REP", "ZRX", "BAT", "KNC", "LINK"];
   beforeEach(async done => {
     ({
       uniswapAnchoredView,
@@ -244,9 +246,8 @@ describe("UniswapAnchoredView", () => {
   it("check initialization of cumulative prices", async () => {
     await Promise.all(Object.keys(pairs).map(async (key) => {
       const [price, timestamp] = await currentCumulativePrice(pairs[key], isReversedMarket(key));
-      const oldObservation = await call(uniswapAnchoredView, "oldObservations", [pairs[key]._address]);
-      const newObservation = await call(uniswapAnchoredView, "newObservations", [pairs[key]._address]);
-
+      const oldObservation = await call(uniswapAnchoredView, "oldObservations", [keccak256(key)]);
+      const newObservation = await call(uniswapAnchoredView, "newObservations", [keccak256(key)]);
       // Sometimes `timestamp` and observation.timestamp are different, adjust cumulative prices to reflect difference
       const diff = await currentCumulativePriceDelta(pairs[key], new BN(timestamp).minus(oldObservation.timestamp).abs().toFixed(), isReversedMarket(key));
       expect(diff.plus(price).toFixed()).toBe(oldObservation.acc);
@@ -257,9 +258,6 @@ describe("UniswapAnchoredView", () => {
 
   it("basic scenario, use real world data", async () => {
     await sendRPC(web3, "evm_increaseTime", [31 * 60]);
-
-    // No data for COMP from Coinbase so far, it is not added to the oracle yet
-    const symbols = ["BTC", "ETH", "DAI", "REP", "ZRX", "BAT", "KNC", "LINK"];
 
     await send(uniswapAnchoredView, "postPrices", [
       messages,
@@ -294,9 +292,6 @@ describe("UniswapAnchoredView", () => {
 
   it("test price events - PriceUpdated, PriceGuarded", async () => {
     await sendRPC(web3, "evm_increaseTime", [31 * 60]);
-
-    // No data for COMP from Coinbase so far, it is not added to the oracle yet
-    const symbols = ["BTC", "ETH", "DAI", "REP", "ZRX", "BAT", "KNC", "LINK"];
 
     const postRes = await send(uniswapAnchoredView, "postPrices", [
       messages,
@@ -343,9 +338,6 @@ describe("UniswapAnchoredView", () => {
   it("test anchor price events - AnchorPriceUpdate", async () => {
     await sendRPC(web3, "evm_increaseTime", [31 * 60]);
 
-    // No data for COMP from Coinbase so far, it is not added to the oracle yet
-    const symbols = ["BTC", "ETH", "DAI", "REP", "ZRX", "BAT", "KNC", "LINK"];
-
     const observations = {};
     await Promise.all(Object.keys(pairs).map(async (key) => {
       const newObservation = await call(uniswapAnchoredView, "newObservations", [pairs[key]._address]);
@@ -363,75 +355,75 @@ describe("UniswapAnchoredView", () => {
     // Check anchor prices
     const block = await sendRPC(web3, "eth_getBlockByNumber", [ anchorEvents[0].blockNumber, false]);
     const blockTimestamp = block.result.timestamp;
-    const cumulativePrice_eth = await getCumulativePrice(pairs.USDC_ETH, blockTimestamp, true);
+    const cumulativePrice_eth = await getCumulativePrice(pairs.ETH, blockTimestamp, true);
     // Recalculate anchor price in JS code and compare to the contract result
-    const ethPrice = calculateTWAP(cumulativePrice_eth, observations["USDC_ETH"].acc, blockTimestamp, observations["USDC_ETH"].timestamp).toFixed();
+    const ethPrice = calculateTWAP(cumulativePrice_eth, observations["ETH"].acc, blockTimestamp, observations["ETH"].timestamp).toFixed();
     await Promise.all(anchorEvents.map(async (anchorEvent) => {
       switch(anchorEvent.returnValues.uniswapMarket) {
-        case pairs.USDC_ETH._address:
+        case pairs.ETH._address:
           expect(anchorEvent.returnValues.anchorPrice).toBe("227415058");
           expect(anchorEvent.returnValues.anchorPrice).toBe(ethPrice);
           break;
-        case pairs.DAI_ETH._address:
+        case pairs.DAI._address:
           expect(anchorEvent.returnValues.anchorPrice).toBe("1019878");
 
           // Recalculate anchor price in JS code and compare to the contract result
-          const cumulativePrice_dai = await getCumulativePrice(pairs.DAI_ETH, blockTimestamp);
-          const daiTWAP = calculateTWAP(cumulativePrice_dai, observations["DAI_ETH"].acc, blockTimestamp, observations["DAI_ETH"].timestamp);
+          const cumulativePrice_dai = await getCumulativePrice(pairs.DAI, blockTimestamp);
+          const daiTWAP = calculateTWAP(cumulativePrice_dai, observations["DAI"].acc, blockTimestamp, observations["DAI"].timestamp);
           const daiPrice = daiTWAP.multipliedBy(ethPrice).dividedBy(1e18).toFixed()
           expect(daiPrice).toBe(anchorEvent.returnValues.anchorPrice);
           break;
-        case pairs.REP_ETH._address:
+        case pairs.REP._address:
           expect(anchorEvent.returnValues.anchorPrice).toBe("17189956");
 
           // Recalculate anchor price in JS code and compare to the contract result
-          const cumulativePrice_rep = await getCumulativePrice(pairs.REP_ETH, blockTimestamp);
-          const repTWAP = calculateTWAP(cumulativePrice_rep, observations["REP_ETH"].acc, blockTimestamp, observations["REP_ETH"].timestamp);
+          const cumulativePrice_rep = await getCumulativePrice(pairs.REP, blockTimestamp);
+          const repTWAP = calculateTWAP(cumulativePrice_rep, observations["REP"].acc, blockTimestamp, observations["REP"].timestamp);
           const repPrice = repTWAP.multipliedBy(ethPrice).dividedBy(1e18).toFixed()
           expect(repPrice).toBe(anchorEvent.returnValues.anchorPrice);
           break;
-        case pairs.BAT_ETH._address:
+        case pairs.BAT._address:
           expect(anchorEvent.returnValues.anchorPrice).toBe("242933");
 
           // Recalculate anchor price in JS code and compare to the contract result
-          const cumulativePrice_bat = await getCumulativePrice(pairs.BAT_ETH, blockTimestamp);
-          const batTWAP = calculateTWAP(cumulativePrice_bat, observations["BAT_ETH"].acc, blockTimestamp, observations["BAT_ETH"].timestamp);
+          const cumulativePrice_bat = await getCumulativePrice(pairs.BAT, blockTimestamp);
+          const batTWAP = calculateTWAP(cumulativePrice_bat, observations["BAT"].acc, blockTimestamp, observations["BAT"].timestamp);
           const batPrice = batTWAP.multipliedBy(ethPrice).dividedBy(1e18).toFixed()
           expect(batPrice).toBe(anchorEvent.returnValues.anchorPrice);
           break;
-        case pairs.ETH_ZRX._address:
+        case pairs.ZRX._address:
           expect(anchorEvent.returnValues.anchorPrice).toBe("359004");
 
           // Recalculate anchor price in JS code and compare to the contract result
-          cumulativePrice_zrx = await getCumulativePrice(pairs.ETH_ZRX, blockTimestamp, true);
-          const zrxTWAP = calculateTWAP(cumulativePrice_zrx, observations["ETH_ZRX"].acc, blockTimestamp, observations["ETH_ZRX"].timestamp);
+          cumulativePrice_zrx = await getCumulativePrice(pairs.ZRX, blockTimestamp, true);
+          const zrxTWAP = calculateTWAP(cumulativePrice_zrx, observations["ZRX"].acc, blockTimestamp, observations["ZRX"].timestamp);
           const zrxPrice = zrxTWAP.multipliedBy(ethPrice).dividedBy(1e18).toFixed()
           expect(zrxPrice).toBe(anchorEvent.returnValues.anchorPrice);
           break;
-        case pairs.WBTC_ETH._address:
+        case pairs.BTC._address:
           expect(anchorEvent.returnValues.anchorPrice).toBe("9154767327");
 
           // Recalculate anchor price in JS code and compare to the contract result
-          const cumulativePrice_wbtc = await getCumulativePrice(pairs.WBTC_ETH, blockTimestamp);
-          const wbtcTWAP = calculateTWAP(cumulativePrice_wbtc, observations["WBTC_ETH"].acc, blockTimestamp, observations["WBTC_ETH"].timestamp);
-          const wbtcPrice = wbtcTWAP.multipliedBy(ethPrice).dividedBy(1e18).dividedBy(1e10).toFixed()
-          expect(wbtcPrice).toBe(anchorEvent.returnValues.anchorPrice);
+          const cumulativePrice_btc = await getCumulativePrice(pairs.BTC, blockTimestamp);
+          const btcTWAP = calculateTWAP(cumulativePrice_btc, observations["BTC"].acc, blockTimestamp, observations["BTC"].timestamp);
+          const btcPrice = btcTWAP.multipliedBy(ethPrice).dividedBy(1e18).dividedBy(1e10).toFixed()
+          expect(btcPrice).toBe(anchorEvent.returnValues.anchorPrice);
           break;
-        case pairs.ETH_KNC._address:
+        case pairs.KNC._address:
           expect(anchorEvent.returnValues.anchorPrice).toBe("1661588");
 
           // Recalculate anchor price in JS code and compare to the contract result
-          cumulativePrice_knc = await getCumulativePrice(pairs.ETH_KNC, blockTimestamp, true);
-          const kncTWAP = calculateTWAP(cumulativePrice_knc, observations["ETH_KNC"].acc, blockTimestamp, observations["ETH_KNC"].timestamp);
+          cumulativePrice_knc = await getCumulativePrice(pairs.KNC, blockTimestamp, true);
+          const kncTWAP = calculateTWAP(cumulativePrice_knc, observations["KNC"].acc, blockTimestamp, observations["KNC"].timestamp);
           const kncPrice = kncTWAP.multipliedBy(ethPrice).dividedBy(1e18).toFixed()
           expect(kncPrice).toBe(anchorEvent.returnValues.anchorPrice);
           break;
-        case pairs.LINK_ETH._address:
+        case pairs.LINK._address:
           expect(anchorEvent.returnValues.anchorPrice).toBe("4820505");
 
           // Recalculate anchor price in JS code and compare to the contract result
-          const cumulativePrice_link = await getCumulativePrice(pairs.LINK_ETH, blockTimestamp);
-          const linkTWAP = calculateTWAP(cumulativePrice_link, observations["LINK_ETH"].acc, blockTimestamp, observations["LINK_ETH"].timestamp);
+          const cumulativePrice_link = await getCumulativePrice(pairs.LINK, blockTimestamp);
+          const linkTWAP = calculateTWAP(cumulativePrice_link, observations["LINK"].acc, blockTimestamp, observations["LINK"].timestamp);
           const linkPrice = linkTWAP.multipliedBy(ethPrice).dividedBy(1e18).toFixed()
           expect(linkPrice).toBe(anchorEvent.returnValues.anchorPrice);
       }
@@ -462,9 +454,6 @@ describe("UniswapAnchoredView", () => {
       "0xafa764b8e63866b81853c8d74e380a8cc7cd14cf2aed22df306f6c4931801a1986ea34f54d4de25f4f3f6a4e968abf42371a6ad3e72b90b2027dc63212fededb000000000000000000000000000000000000000000000000000000000000001b",
       "0x039f30fb49b2f2badad1e3c5df00f2c5c2124c2a1bd06da56467aea45ebf89a027525cc7bfa776452171cb5865e74ef0c04ea6ef18d6ca2e556a0686af658803000000000000000000000000000000000000000000000000000000000000001b",
     ];
-
-    // No data for COMP from Coinbase so far, it is not added to the oracle yet
-    const symbols = ["BTC", "ETH", "DAI", "REP", "ZRX", "BAT", "KNC", "LINK"];
 
     const postRes1 = await send(uniswapAnchoredView, "postPrices", [
       messages,
@@ -499,12 +488,12 @@ describe("UniswapAnchoredView", () => {
   });
 
   it("test ETH pair while token reserves change", async() => {
-    // Emulate timeElapsed for USDC_ETH token pair, so that timestamps are set up correctly
+    // Emulate timeElapsed for ETH token pair, so that timestamps are set up correctly
     // 1594232101 - 1593755855 = 476246
     await sendRPC(web3, "evm_increaseTime", [476246]);
 
     // Update reserves, last block timestamp and cumulative prices for uniswap token pair
-    await send(pairs.USDC_ETH, "update", ["2699846518724", "10900804290754780075806", "1594232101", "130440674219479413955332918569393260852443923640848", "6394369143386285784459187027043"]);
+    await send(pairs.ETH, "update", ["2699846518724", "10900804290754780075806", "1594232101", "130440674219479413955332918569393260852443923640848", "6394369143386285784459187027043"]);
     const messages1 = ["0x0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000005f060cac00000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000eb20df00000000000000000000000000000000000000000000000000000000000000006707269636573000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034554480000000000000000000000000000000000000000000000000000000000"];
     const signatures1 = ["0x3b5dd2e97c072df44a576f1599a1a7beecef194596c0924c6f696f05c46e7494637041f819e7c89c897327f5932dddc3e4c811793bf5378bcd2289e3c2bd6210000000000000000000000000000000000000000000000000000000000000001b"];
     const symbols1 = ["ETH"];
@@ -513,20 +502,20 @@ describe("UniswapAnchoredView", () => {
       signatures1,
       symbols1,
     ]);
-    const oldObservation1 = await call(uniswapAnchoredView, "oldObservations", [pairs["USDC_ETH"]._address]);
+    const oldObservation1 = await call(uniswapAnchoredView, "oldObservations", [keccak256('ETH')]);
     const anchorEvent1 = postRes1.events.AnchorPriceUpdate;
     const block1 = await sendRPC(web3, "eth_getBlockByNumber", [anchorEvent1.blockNumber, false]);
     const blockTimestamp1 = block1.result.timestamp;
 
-    const cumulativePrice_eth1 = await getCumulativePrice(pairs.USDC_ETH, blockTimestamp1, true);
+    const cumulativePrice_eth1 = await getCumulativePrice(pairs.ETH, blockTimestamp1, true);
     const ethPrice1 = calculateTWAP(cumulativePrice_eth1, oldObservation1.acc, blockTimestamp1, oldObservation1.timestamp).toFixed();
     expect(anchorEvent1.returnValues.anchorPrice).toBe(ethPrice1);
 
-    // Emulate timeElapsed for USDC_ETH token pair, so that timestamps are set up correctly
+    // Emulate timeElapsed for ETH token pair, so that timestamps are set up correctly
     // 1594232585 - 1594232101 = 484
     await sendRPC(web3, "evm_increaseTime", [484]);
     // Update reserves, last block timestamp and cumulative prices for uniswap token pair
-    await send(pairs.USDC_ETH, "update", ["2699481954534", "10928542275748114013210", "1594232585", "130450824938813990811384244472088515000814627335952", "6394991319166063175850559023838"]);
+    await send(pairs.ETH, "update", ["2699481954534", "10928542275748114013210", "1594232585", "130450824938813990811384244472088515000814627335952", "6394991319166063175850559023838"]);
     const messages2 = ["0x0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000005f060e8c00000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000eb2aa300000000000000000000000000000000000000000000000000000000000000006707269636573000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034554480000000000000000000000000000000000000000000000000000000000"];
     const signatures2 = ["0xa9f78f3b7b3f35b124b186fc30a49418cde2baf40b01f7e710239a5e1c4c68bc0e1ae1abd93d3a79c20d4a742983fffd63ab5b239d36d77051ee265e36819920000000000000000000000000000000000000000000000000000000000000001b"];
     const symbols2 = ["ETH"];
@@ -535,11 +524,11 @@ describe("UniswapAnchoredView", () => {
       signatures2,
       symbols2,
     ]);
-    const oldObservation2 = await call(uniswapAnchoredView, "oldObservations", [pairs["USDC_ETH"]._address]);
+    const oldObservation2 = await call(uniswapAnchoredView, "oldObservations", [keccak256('ETH')]);
     const anchorEvent2 = postRes2.events.AnchorPriceUpdate;
     const block2 = await sendRPC(web3, "eth_getBlockByNumber", [anchorEvent2.blockNumber, false]);
     const blockTimestamp2 = block2.result.timestamp;
-    const cumulativePrice_eth2 = await getCumulativePrice(pairs.USDC_ETH, blockTimestamp2, true);
+    const cumulativePrice_eth2 = await getCumulativePrice(pairs.ETH, blockTimestamp2, true);
     const ethPrice2 = calculateTWAP(cumulativePrice_eth2, oldObservation2.acc, blockTimestamp2, oldObservation2.timestamp).toFixed();
 
     expect(anchorEvent2.returnValues.anchorPrice).toBe(ethPrice2);

--- a/tests/UniswapAnchoredViewTest.js
+++ b/tests/UniswapAnchoredViewTest.js
@@ -14,11 +14,11 @@ async function setup(opts)  {
   await sendRPC(web3, 'evm_mine', [fixed(1.6e9)]);
 
   const mockPair = await deploy("MockUniswapTokenPair", [
-    "1865335786147",
-    "8202340665419053945756",
-    "1593755855",
-    "119785032308978310142960133641565753500432674230537",
-    "5820053774558372823476814618189",
+    fixed(1.8e12),
+    fixed(8.2e21),
+    fixed(1.6e9),
+    fixed(1.19e50),
+    fixed(5.8e30),
   ]);
 
   const priceSource = {FIXED_ETH: 0, FIXED_USD: 1, REPORTER: 2};
@@ -227,10 +227,8 @@ describe('UniswapAnchoredView', () => {
     it('should not update window values if not enough time elapsed', async () => {
       const timestamp = Number(await currentBlockTimestamp(web3)) + anchorPeriod - 3;
       await sendRPC(web3, 'evm_increaseTime', [anchorPeriod - 5]);
-      const tx = await postPrices(timestamp, [[['ETH', 200]]], ['ETH']);
+      const tx = await postPrices(timestamp, [[['ETH', 227]]], ['ETH']);
       expect(tx.events.UniswapWindowUpdate).toBe(undefined);
-      expect(tx.events.PriceGuarded).not.toBe(undefined);
-
     });
 
     it('should update window values if enough time elapsed', async () => {

--- a/tests/UniswapAnchoredViewTest.js
+++ b/tests/UniswapAnchoredViewTest.js
@@ -12,12 +12,13 @@ async function setup(opts)  {
   const FIXED_ETH_AMOUNT = 0.005e18;
 
   await sendRPC(web3, 'evm_mine', [fixed(1.6e9)]);
+
   const mockPair = await deploy("MockUniswapTokenPair", [
-    fixed(1.5e23),
-    fixed(1e22),
-    fixed(1.6e9),//timestamp
-    fixed(8e38),
-    fixed(2e41)// acc
+    "1865335786147",
+    "8202340665419053945756",
+    "1593755855",
+    "119785032308978310142960133641565753500432674230537",
+    "5820053774558372823476814618189",
   ]);
 
   const priceSource = {FIXED_ETH: 0, FIXED_USD: 1, REPORTER: 2};
@@ -29,7 +30,7 @@ async function setup(opts)  {
     {cToken: cToken.REP, underlying: dummyAddress, symbolHash: keccak256('REP'), baseUnit: uint(1e18), priceSource: priceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: false},
     {cToken: cToken.USDT, underlying: dummyAddress, symbolHash: keccak256('USDT'), baseUnit: uint(1e6), priceSource: priceSource.FIXED_USD, fixedPrice: uint(1e6), uniswapMarket: address(0), isUniswapReversed: false},
     {cToken: cToken.SAI, underlying: dummyAddress, symbolHash: keccak256('SAI'), baseUnit: uint(1e18), priceSource: priceSource.FIXED_ETH, fixedPrice: uint(FIXED_ETH_AMOUNT), uniswapMarket: address(0), isUniswapReversed: false},
-    {cToken: cToken.WBTC, underlying: dummyAddress, symbolHash: keccak256('WBTC'), baseUnit: uint(1e8), priceSource: priceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: false},
+    {cToken: cToken.WBTC, underlying: dummyAddress, symbolHash: keccak256('BTC'), baseUnit: uint(1e8), priceSource: priceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: false},
   ];
 
   let uniswapAnchoredView;
@@ -89,8 +90,6 @@ describe('UniswapAnchoredView', () => {
       const tx = await postPrices(timestamp, [[['ETH', 91]]], ['ETH']);
 
       expect(tx.events.PriceGuarded).toBe(undefined);
-      expect(tx.events.PriceUpdated).not.toBe(undefined);
-      expect(tx.events.PriceUpdated.returnValues.symbol).toBe('ETH');
       expect(tx.events.PriceUpdated.returnValues.price).numEquals(91e6);
       expect(await call(uniswapAnchoredView, 'prices', [keccak256('ETH')])).numEquals(91e6);
       expect(await call(priceData, 'getPrice', [reporter.address, 'ETH'])).numEquals(91e6);
@@ -102,8 +101,6 @@ describe('UniswapAnchoredView', () => {
       await send(uniswapAnchoredView, 'setAnchorPrice', ['ETH', 89.9e6]);
       const tx = await postPrices(timestamp, [[['ETH', 100]]], ['ETH']);
 
-      expect(tx.events.PriceGuarded).not.toBe(undefined);
-      expect(tx.events.PriceGuarded.returnValues.symbol).toBe('ETH');
       expect(tx.events.PriceGuarded.returnValues.reporter).numEquals(100e6);
       expect(tx.events.PriceGuarded.returnValues.anchor).numEquals(89.9e6);
       expect(tx.events.PriceUpdated).toBe(undefined);
@@ -117,8 +114,6 @@ describe('UniswapAnchoredView', () => {
       await send(uniswapAnchoredView, 'setAnchorPrice', ['ETH', 110.1e6]);
       const tx = await postPrices(timestamp, [[['ETH', 100]]], ['ETH']);
 
-      expect(tx.events.PriceGuarded).not.toBe(undefined);
-      expect(tx.events.PriceGuarded.returnValues.symbol).toBe('ETH');
       expect(tx.events.PriceGuarded.returnValues.reporter).numEquals(100e6);
       expect(tx.events.PriceGuarded.returnValues.anchor).numEquals(110.1e6);
       expect(tx.events.PriceUpdated).toBe(undefined);
@@ -209,12 +204,12 @@ describe('UniswapAnchoredView', () => {
     it('should return reported WBTC price', async () => {
       const timestamp = time() - 5;
       await send(uniswapAnchoredView, 'setAnchorPrice', ['ETH', 200e6]);
-      await send(uniswapAnchoredView, 'setAnchorPrice', ['WBTC', 10000e6]);
+      await send(uniswapAnchoredView, 'setAnchorPrice', ['BTC', 10000e6]);
 
-      const tx = await postPrices(timestamp, [[['ETH', 200], ['WBTC', 10000]]], ['ETH', 'WBTC']);
-      const wbtcPrice  = await call(uniswapAnchoredView, 'prices', [keccak256('WBTC')]);
+      const tx = await postPrices(timestamp, [[['ETH', 200], ['BTC', 10000]]], ['ETH', 'BTC']);
+      const btcPrice  = await call(uniswapAnchoredView, 'prices', [keccak256('BTC')]);
 
-      expect(wbtcPrice).numEquals(10000e6);
+      expect(btcPrice).numEquals(10000e6);
       // priceInternal:      returns 10000e6
       // getUnderlyingPrice: 1e30 * 10000e6 / 1e8 = 1e32
       let expected = new BigNumber('1e32');
@@ -234,23 +229,28 @@ describe('UniswapAnchoredView', () => {
       await sendRPC(web3, 'evm_increaseTime', [anchorPeriod - 5]);
       const tx = await postPrices(timestamp, [[['ETH', 200]]], ['ETH']);
       expect(tx.events.UniswapWindowUpdate).toBe(undefined);
+      expect(tx.events.PriceGuarded).not.toBe(undefined);
+
     });
 
     it('should update window values if enough time elapsed', async () => {
+      const ethHash = keccak256('ETH');
       let timestamp;
       const mkt = mockPair._address;// ETH's mock market
-      const newObs1 = await call(uniswapAnchoredView, 'newObservations', [mkt]);
-      const oldObs1 = await call(uniswapAnchoredView, 'oldObservations', [mkt]);
+      const newObs1 = await call(uniswapAnchoredView, 'newObservations', [ethHash]);
+      const oldObs1 = await call(uniswapAnchoredView, 'oldObservations', [ethHash]);
 
       timestamp = Number(await currentBlockTimestamp(web3)) + anchorPeriod;
       await sendRPC(web3, 'evm_increaseTime', [anchorPeriod]);
 
-      const tx1 = await postPrices(timestamp, [[['ETH', 200]]], ['ETH']);
-      expect(tx1.events.UniswapWindowUpdate).not.toBe(undefined);
+      const tx1 = await postPrices(timestamp, [[['ETH', 227]]], ['ETH']);
+      const updateEvent = tx1.events.AnchorPriceUpdate.returnValues;
+      expect(updateEvent.nowCumulativePrice).greaterThan(updateEvent.oldCumulativePrice);
+      expect(tx1.events.PriceGuarded).toBe(undefined);
 
       // on the first update, we expect the new observation to change
-      const newObs2 = await call(uniswapAnchoredView, 'newObservations', [mkt]);
-      const oldObs2 = await call(uniswapAnchoredView, 'oldObservations', [mkt]);
+      const newObs2 = await call(uniswapAnchoredView, 'newObservations', [ethHash]);
+      const oldObs2 = await call(uniswapAnchoredView, 'oldObservations', [ethHash]);
       expect(newObs2.acc).greaterThan(newObs1.acc);
       expect(newObs2.timestamp).greaterThan(newObs1.timestamp);
       expect(oldObs2.acc).numEquals(oldObs1.acc);
@@ -261,13 +261,13 @@ describe('UniswapAnchoredView', () => {
       const tx2 = await postPrices(timestamp, [[['ETH', 201]]], ['ETH']);
 
       const windowUpdate = tx2.events.UniswapWindowUpdate.returnValues;
-      expect(windowUpdate.uniswapMarket).toEqual(mkt);
+      expect(windowUpdate.symbolHash).toEqual(ethHash);
       expect(timestamp).greaterThan(windowUpdate.oldTimestamp);
       expect(windowUpdate.newPrice).greaterThan(windowUpdate.oldPrice);// accumulator should always go up
 
       // this time, both should change
-      const newObs3 = await call(uniswapAnchoredView, 'newObservations', [mkt]);
-      const oldObs3 = await call(uniswapAnchoredView, 'oldObservations', [mkt]);
+      const newObs3 = await call(uniswapAnchoredView, 'newObservations', [ethHash]);
+      const oldObs3 = await call(uniswapAnchoredView, 'oldObservations', [ethHash]);
       expect(newObs3.acc).greaterThan(newObs2.acc);
       expect(newObs3.acc).greaterThan(newObs2.timestamp);
       // old becomes last new
@@ -399,12 +399,12 @@ describe('UniswapAnchoredView', () => {
     it("basic scenario, return anchor price after reporter is invalidated", async () => {
       const timestamp = time() - 5;
       await send(uniswapAnchoredView, 'setAnchorPrice', ['ETH', 200e6]);
-      await send(uniswapAnchoredView, 'setAnchorPrice', ['WBTC', 10000e6]);
+      await send(uniswapAnchoredView, 'setAnchorPrice', ['BTC', 10000e6]);
 
-      await postPrices(timestamp, [[['ETH', 201], ['WBTC', 10001]]], ['ETH', 'WBTC']);
+      await postPrices(timestamp, [[['ETH', 201], ['BTC', 10001]]], ['ETH', 'BTC']);
 
       // Check that prices = posted prices
-      const wbtcPrice1  = await call(uniswapAnchoredView, 'prices', [keccak256('WBTC')]);
+      const wbtcPrice1  = await call(uniswapAnchoredView, 'prices', [keccak256('BTC')]);
       const ethPrice1  = await call(uniswapAnchoredView, 'prices', [keccak256('ETH')]);
       expect(wbtcPrice1).numEquals(10001e6);
       expect(ethPrice1).numEquals(201e6);
@@ -415,10 +415,10 @@ describe('UniswapAnchoredView', () => {
       const [ signed ] = sign(encoded, reporter.privateKey);
 
       await send(uniswapAnchoredView, 'invalidateReporter', [encoded, signed.signature]);
-      await postPrices(timestamp, [[['ETH', 201], ['WBTC', 10001]]], ['ETH', 'WBTC']);
+      await postPrices(timestamp, [[['ETH', 201], ['BTC', 10001]]], ['ETH', 'BTC']);
 
       // Check that prices = anchor prices
-      const wbtcPrice2  = await call(uniswapAnchoredView, 'prices', [keccak256('WBTC')]);
+      const wbtcPrice2  = await call(uniswapAnchoredView, 'prices', [keccak256('BTC')]);
       const ethPrice2  = await call(uniswapAnchoredView, 'prices', [keccak256('ETH')]);
       expect(wbtcPrice2).numEquals(10000e6);
       expect(ethPrice2).numEquals(200e6);


### PR DESCRIPTION
Key `newObservations` `oldObservations` mappings off of symbol hash instead of uniswap, to avoid collisions. also add some more tests for event values