### PR TITLE
Add Compound Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 yarn-error.log
 junit.xml
 coverage/*
+.saddle_history

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "compound-config"]
+	path = compound-config
+	url = https://github.com/compound-finance/compound-config.git

--- a/saddle.config.js
+++ b/saddle.config.js
@@ -132,5 +132,27 @@ module.exports = {
         { file: "~/.ethereum/mainnet" }                   // Load from given file with contents as the private key (e.g. 0x...)
       ]
     }
+  },
+  get_network_file: (network) => {
+    return null;
+  },
+  read_network_file: (network) => {
+    const fs = require('fs');
+    const path = require('path');
+    const util = require('util');
+
+    const networkFile = path.join(process.cwd(), 'compound-config', 'networks', `${network}.json`);
+    return util.promisify(fs.readFile)(networkFile).then((json) => {
+      const contracts = JSON.parse(json)['Contracts'] || {};
+
+      return Object.fromEntries(Object.entries(contracts).map(([contract, address]) => {
+        const mapper = {
+          PriceFeed: 'UniswapAnchoredView',
+          PriceData: 'OpenOraclePriceData'
+        };
+
+        return [mapper[contract] || contract, address];
+      }));
+    });
   }
 };


### PR DESCRIPTION
This patch adds Compound Config to the Open Oracle that allows us to trac the Compound Config repo. This means, for instance, when you run a `saddle console -n mainnet`, you'll actually have access to the Open Price Feed contracts. This makes it easy to get a console and interact with the OPF.