### PR TITLE
Add Open Oracle v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 yarn-error.log
 junit.xml
 coverage/*
+.saddle_history

--- a/contracts/v1/OpenOracleV1.sol
+++ b/contracts/v1/OpenOracleV1.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.6.10;
+pragma experimental ABIEncoderV2;
+
+import "../Uniswap/UniswapAnchoredView.sol";
+
+interface IPriceOracle {
+	function assetPrices(address) external returns (uint256);
+	function getPrices(address) external returns (uint256);
+}
+
+/**
+ * @title Open Oracle Adapater for v1 Interface
+ * @author Compound Labs, Inc.
+ */
+contract OpenOracleV1 is IPriceOracle {
+	UniswapAnchoredView public immutable openOracleView;
+
+	constructor(UniswapAnchoredView openOracleView_) public {
+		openOracleView = openOracleView_;
+	}
+
+	function getPrices(address asset) public override returns (uint256) {
+		UniswapConfig.TokenConfig memory ethConfig = openOracleView.getTokenConfigBySymbol("ETH");
+		UniswapConfig.TokenConfig memory cTokenConfig = openOracleView.getTokenConfigByUnderlying(asset);
+		uint tokenPrice = openOracleView.getUnderlyingPrice(cTokenConfig.cToken);
+		uint ethPrice = openOracleView.getUnderlyingPrice(ethConfig.cToken);
+		require(ethPrice != 0, "eth price 0");
+		return mul(tokenPrice, 1e18) / ethPrice;
+	}
+
+	function assetPrices(address asset) public override returns (uint256) {
+		return getPrices(asset);
+	}
+
+	/// @dev Overflow proof multiplication
+    function mul(uint a, uint b) internal pure returns (uint) {
+        if (a == 0) return 0;
+        uint c = a * b;
+        require(c / a == b, "multiplication overflow");
+        return c;
+    }
+}

--- a/tests/OpenOracleV1Test.js
+++ b/tests/OpenOracleV1Test.js
@@ -1,0 +1,70 @@
+const { setup } = require('./UniswapAnchoredViewTest.js');
+const { keccak256, time } = require('./Helpers');
+const BigNumber = require('bignumber.js');
+
+
+describe('UniswapAnchoredView', () => {
+  let cToken;
+  let token;
+  let uniswapAnchoredView;
+  let postPrices;
+
+  describe('getUnderlyingPrice', () => {
+    beforeEach(async () => {
+      console.log("Hi");
+      ({
+        cToken,
+        token,
+        postPrices,
+        uniswapAnchoredView,
+      } = await setup({isMockedView: true}));
+    });
+
+    it('should return reported WBTC price', async () => {
+      let openOracleV1 = await deploy('OpenOracleV1', [uniswapAnchoredView._address]);
+      const timestamp = time() - 5;
+      await send(uniswapAnchoredView, 'setAnchorPrice', ['ETH', 200e6]);
+      await send(uniswapAnchoredView, 'setAnchorPrice', ['BTC', 10000e6]);
+      await send(uniswapAnchoredView, 'setAnchorPrice', ['DAI', 1e6]);
+
+      const tx = await postPrices(timestamp, [[['ETH', 200], ['BTC', 10000], ['DAI', 1]]], ['ETH', 'BTC', 'DAI']);
+      const btcPrice  = await call(uniswapAnchoredView, 'prices', [keccak256('BTC')]);
+
+      expect(btcPrice).numEquals(10000e6);
+      // priceInternal:      returns 10000e6
+      // getUnderlyingPrice: 1e30 * 10000e6 / 1e8 = 1e32
+      let expected = new BigNumber('1e32');
+      expect(await call(uniswapAnchoredView, 'getUnderlyingPrice', [cToken.WBTC])).numEquals(expected.toFixed());
+
+      /*
+        BTC = 10000
+        ETH = 200
+        BTC/ETH = 50
+        Decimalized: 50e28 (18 - 6 decimals = 12 + 18)
+      */
+      expect(
+        await call(openOracleV1, 'getPrices', [token.WBTC]))
+          .numEquals(new BigNumber('50e28').toFixed());
+
+      /*
+        ETH = 200
+        ETH = 200
+        ETH/ETH = 1
+        Decimalized: 1e18 (18 - 18 decimals = 0 + 18)
+      */
+      expect(
+        await call(openOracleV1, 'getPrices', [token.WETH]))
+          .numEquals(new BigNumber('1e18').toFixed());
+
+      /*
+        DAI = 1
+        ETH = 200
+        DAI/ETH = 0.005
+        Decimalized: 0.005e18 (18 - 18 decimals = 0 + 18)
+      */
+      expect(
+        await call(openOracleV1, 'getPrices', [token.DAI]))
+          .numEquals(new BigNumber('0.005e18').toFixed());
+    });
+  });
+});

--- a/tests/UniswapAnchoredViewTest.js
+++ b/tests/UniswapAnchoredViewTest.js
@@ -43,14 +43,14 @@ async function setup({isMockedView, freeze}) {
   ]);
 
   const cToken = {ETH: address(1), DAI: address(2), REP: address(3), USDT: address(4), SAI: address(5), WBTC: address(6)};
-  const dummyAddress = address(0);
+  const token = {WETH: address(10), DAI: address(20), REP: address(30), USDT: address(40), SAI: address(50), WBTC: address(60)};
   const tokenConfigs = [
-    {cToken: cToken.ETH, underlying: dummyAddress, symbolHash: keccak256('ETH'), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: true},
-    {cToken: cToken.DAI, underlying: dummyAddress, symbolHash: keccak256('DAI'), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: false},
-    {cToken: cToken.REP, underlying: dummyAddress, symbolHash: keccak256('REP'), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockRepPair._address, isUniswapReversed: false},
-    {cToken: cToken.USDT, underlying: dummyAddress, symbolHash: keccak256('USDT'), baseUnit: uint(1e6), priceSource: PriceSource.FIXED_USD, fixedPrice: uint(1e6), uniswapMarket: address(0), isUniswapReversed: false},
-    {cToken: cToken.SAI, underlying: dummyAddress, symbolHash: keccak256('SAI'), baseUnit: uint(1e18), priceSource: PriceSource.FIXED_ETH, fixedPrice: uint(FIXED_ETH_AMOUNT), uniswapMarket: address(0), isUniswapReversed: false},
-    {cToken: cToken.WBTC, underlying: dummyAddress, symbolHash: keccak256('BTC'), baseUnit: uint(1e8), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: false},
+    {cToken: cToken.ETH, underlying: token.WETH, symbolHash: keccak256('ETH'), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: true},
+    {cToken: cToken.DAI, underlying: token.DAI, symbolHash: keccak256('DAI'), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: false},
+    {cToken: cToken.REP, underlying: token.REP, symbolHash: keccak256('REP'), baseUnit: uint(1e18), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockRepPair._address, isUniswapReversed: false},
+    {cToken: cToken.USDT, underlying: token.USDT, symbolHash: keccak256('USDT'), baseUnit: uint(1e6), priceSource: PriceSource.FIXED_USD, fixedPrice: uint(1e6), uniswapMarket: address(0), isUniswapReversed: false},
+    {cToken: cToken.SAI, underlying: token.SAI, symbolHash: keccak256('SAI'), baseUnit: uint(1e18), priceSource: PriceSource.FIXED_ETH, fixedPrice: uint(FIXED_ETH_AMOUNT), uniswapMarket: address(0), isUniswapReversed: false},
+    {cToken: cToken.WBTC, underlying: token.WBTC, symbolHash: keccak256('BTC'), baseUnit: uint(1e8), priceSource: PriceSource.REPORTER, fixedPrice: 0, uniswapMarket: mockPair._address, isUniswapReversed: false},
   ];
 
   let uniswapAnchoredView;
@@ -89,6 +89,7 @@ async function setup({isMockedView, freeze}) {
     anchorMantissa,
     anchorPeriod,
     cToken,
+    token,
     mockPair,
     postPrices,
     priceData,
@@ -556,3 +557,7 @@ describe('UniswapAnchoredView', () => {
     });
   })
 });
+
+module.exports = {
+  setup
+};


### PR DESCRIPTION
This patch adds an open oracle v1 which is meant to align with the interface of the v1 oracle but support reading data from the open oracle. We simply use the token configuration information to pull the correct prices, in terms of Eth, for the given asset requeest.